### PR TITLE
chore: archon v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "standard-version": "^4.4.0"
   },
   "dependencies": {
-    "@kleros/archon": "^0.8.0",
+    "@kleros/archon": "^0.9.0",
     "@loadable/component": "^5.5.0",
     "@realitio/realitio-lib": "^1.0.2",
     "@sentry/browser": "^4.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,10 +1055,10 @@
     log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
-"@kleros/archon@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@kleros/archon/-/archon-0.8.0.tgz#5a871ac8b6a72ee8eb7b5b16914fbf2d1b4af8cd"
-  integrity sha512-GOyd6+sW7WLsbOnaFGNf6XYjMdn4aIeGsRv+Fdkx727MPQTe0TsUWAhsdm6ntn2EUd6dDs5GlfsAgK66sRdB8w==
+"@kleros/archon@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@kleros/archon/-/archon-0.9.0.tgz#024dafea86cf8ff614347cae4c19839400cef96d"
+  integrity sha512-uR/OoeL4gvoCMMYary7KpDJ8cbQqBeBwJ2QQJeEucBw2kQGgIIqKQE2uuPCluwi3aR6sdmIlxdtoh+BbeI8J0Q==
   dependencies:
     "@kleros/kleros-interaction" "^0.7.0"
     axios "^0.18.0"


### PR DESCRIPTION
- This version of Archon is compatible with the Realitio scripts that are currently deployed