### PR TITLE
refactor(case-details-card): hide history if not single-select

### DIFF
--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -750,8 +750,16 @@ const CaseDetailsCard = ({ ID }) => {
               </Row>
             )}
           </Skeleton>
-          <Divider>History</Divider>
           {dispute2 &&
+            metaEvidence &&
+            metaEvidence.metaEvidenceJSON.rulingOptions &&
+            metaEvidence.metaEvidenceJSON.rulingOptions.type ===
+              'single-select' && <Divider>History</Divider>}
+          {dispute2 &&
+            metaEvidence &&
+            metaEvidence.metaEvidenceJSON.rulingOptions &&
+            metaEvidence.metaEvidenceJSON.rulingOptions.type ===
+              'single-select' &&
             dispute2.votesLengths.map((_, i) => (
               <CaseRoundHistory
                 ID={ID}


### PR DESCRIPTION
History does not work with `complexRulings`. Hide it if not `single-select` until they have been implemented.