### PR TITLE
fix: show correct evidence links

### DIFF
--- a/src/components/evidence-card.js
+++ b/src/components/evidence-card.js
@@ -104,8 +104,8 @@ const EvidenceCard = ({ evidence, metaEvidence }) => {
             </Col>
             <Col lg={1}>
               <Attachment
-                URI={metaEvidence.fileURI}
-                extension={metaEvidence.fileTypeExtension}
+                URI={evidence.evidenceJSON.fileURI}
+                extension={evidence.evidenceJSON.fileTypeExtension}
               />
             </Col>
           </Row>


### PR DESCRIPTION
use correct evidence file