### PR TITLE
refactor(cases): optional height for evidence display

### DIFF
--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -219,7 +219,6 @@ const StyledInnerCard = styled(Card)`
   }
 `
 const StyledIFrame = styled.iframe`
-  height: 215px;
   width: 100%;
 `
 const StyledInnerCardActionsTitleDiv = styled.div`
@@ -781,6 +780,7 @@ const CaseDetailsCard = ({ ID }) => {
                       })
                     )}`}
                     title="MetaEvidence Display"
+                    height={metaEvidence.metaEvidenceJSON.evidenceDisplayHeight || '215px'}
                   />
                 )}
                 {metaEvidence.metaEvidenceJSON.arbitrableInterfaceURI && (


### PR DESCRIPTION
allows for the use of parameter `evidenceDisplayHeight` in meta evidence to change the rendered height of the evidence display iFrame