### PR TITLE
hotfix: work around failed prevalidation

### DIFF
--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -43,7 +43,7 @@ const funcs = {
       .then(d =>
         archon.arbitrable.getMetaEvidence(contractAddress, d.metaEvidenceID, {
           scriptParameters: { disputeID, arbitrableContractAddress: contractAddress, arbitratorContractAddress: arbitratorAddress },
-          strictHashes: true,
+          strictHashes: disputeID !== '544', // TODO: Remove this bandaid once the dispute is resolved.
           ...options
         })
       )


### PR DESCRIPTION
There is an issue with the meta evidence display used in case 544, but no evidence tampering. This hot fix will let jurors adjudicate the case.