### PR TITLE
fix/broken-meta-evidence

### DIFF
--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -41,15 +41,19 @@ const funcs = {
         ...options
       })
       .then(d =>
-        archon.arbitrable.getMetaEvidence(contractAddress, d.metaEvidenceID, {
-          scriptParameters: {
-            disputeID,
-            arbitrableContractAddress: contractAddress,
-            arbitratorContractAddress: arbitratorAddress
-          },
-          strictHashes: true,
-          ...options
-        })
+        archon.arbitrable.getMetaEvidence(
+          contractAddress,
+          disputeID === '560' ? '2' : d.metaEvidenceID,
+          {
+            scriptParameters: {
+              disputeID,
+              arbitrableContractAddress: contractAddress,
+              arbitratorContractAddress: arbitratorAddress
+            },
+            strictHashes: true,
+            ...options
+          }
+        )
       )
       .catch(e => {
         console.log(e)


### PR DESCRIPTION
Profile of case 560 was submitted before the launch of PoH, while the contract had an outdated buggy meta evidence file. Someone challenged it and now jurors cannot see the case properly.
This patches the issue so jurors can vote.