### PR TITLE
fix(claim-modal): filter already claimed weeks

### DIFF
--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -185,7 +185,9 @@ const ClaimModal = ({
       MerkleRedeem.abi,
       CONTRACT_ADDRESSES[drizzleState.web3.networkId]
     )
-    const args = claimObjects(claims)
+    const args = claimObjects(claims).filter(
+      (claim, index) => claimStatus[index] == false
+    )
 
     setCurrentClaimValue(
       args


### PR DESCRIPTION
Bug: Transaction payload does not filter out already claimed `weeks`. This causes the claim transaction to revert if you already claimed the past period.

How to Reproduce: Try to claim your reward and see that tx is reverting if you have claimed in a past period at least once.

How to Verify This Fix: Try to claim your reward on deploy preview. The transaction should be successful and you should see the amount you received with this transaction, in the modal, as a result.

Please merge if you approve, this needs to be live asap.