### PR TITLE
Fix: made deadline display to take the full parent width

### DIFF
--- a/src/containers/case.js
+++ b/src/containers/case.js
@@ -39,10 +39,7 @@ export default ({
   const drizzleState = useDrizzleState(drizzleState => ({
     account: drizzleState.accounts[0] || VIEW_ONLY_ADDRESS
   }))
-  const { send: sendPassPeriod } = useCacheSend(
-    'KlerosLiquid',
-    'passPeriod'
-  )
+  const { send: sendPassPeriod } = useCacheSend('KlerosLiquid', 'passPeriod')
   const { send: sendExecuteRuling } = useCacheSend(
     'KlerosLiquid',
     'executeRuling'
@@ -122,7 +119,7 @@ export default ({
             ) : (
               <>
                 {disputeData.deadline && (
-                  <Col lg={12}>
+                  <Col lg={disputeData.showPassPeriod ? 12 : 24}>
                     <StyledDiv>
                       {
                         ['Evidence', 'Commit', 'Vote', 'Appeal', 'Execute'][


### PR DESCRIPTION
This should be the case when there is no manual period passing button to be displayed.

Fixes #170.