### PR TITLE
Feat: store committed votes locally

### DIFF
--- a/src/components/attachment.js
+++ b/src/components/attachment.js
@@ -1,15 +1,15 @@
-import { Divider, Popover } from 'antd'
-import { ReactComponent as Document } from '../assets/images/document.svg'
-import { ReactComponent as Image } from '../assets/images/image.svg'
-import { ReactComponent as Link } from '../assets/images/link.svg'
-import { ReactComponent as PDF } from '../assets/images/pdf.svg'
-import PropTypes from 'prop-types'
-import React from 'react'
-import { ReactComponent as Video } from '../assets/images/video.svg'
-import isImage from 'is-image'
-import isTextPath from 'is-text-path'
-import isVideo from 'is-video'
-import styled from 'styled-components/macro'
+import React from "react";
+import t from "prop-types";
+import styled from "styled-components/macro";
+import { Divider, Popover } from "antd";
+import isImage from "is-image";
+import isTextPath from "is-text-path";
+import isVideo from "is-video";
+import { ReactComponent as Document } from "../assets/images/document.svg";
+import { ReactComponent as Image } from "../assets/images/image.svg";
+import { ReactComponent as Link } from "../assets/images/link.svg";
+import { ReactComponent as PDF } from "../assets/images/pdf.svg";
+import { ReactComponent as Video } from "../assets/images/video.svg";
 
 const StyledPopover = styled(({ className, ...rest }) => (
   <Popover className={className} overlayClassName={className} {...rest} />
@@ -23,46 +23,36 @@ const StyledPopover = styled(({ className, ...rest }) => (
       color: inherit;
     }
   }
-`
+`;
 const StyledIFrame = styled.iframe`
   height: 400px;
   margin-top: -8px;
   width: 300px;
-`
+`;
 
-const isPDF = extension => extension.toLowerCase() === '.pdf'
+const isPDF = (extension) => extension.toLowerCase() === ".pdf";
 
-const Attachment = ({
-  URI,
-  description,
-  extension: _extension,
-  previewURI,
-  title
-}) => {
-  let extension
-  if (!_extension && URI) extension = `.${URI.split('.').pop()}`
-  else extension = `.${_extension}`
-  let Component
-  if (!URI) Component = Document
-  else if (isPDF(extension)) Component = PDF
-  else if (isTextPath(extension)) Component = Document
-  else if (isImage(extension)) Component = Image
-  else if (isVideo(extension)) Component = Video
-  else Component = Link
-  Component = <Component className="ternary-fill theme-fill" />
+const Attachment = ({ URI, description, extension: _extension, previewURI, title }) => {
+  let extension;
+  if (!_extension && URI) extension = `.${URI.split(".").pop()}`;
+  else extension = `.${_extension}`;
+  let Component;
+  if (!URI) Component = Document;
+  else if (isPDF(extension)) Component = PDF;
+  else if (isTextPath(extension)) Component = Document;
+  else if (isImage(extension)) Component = Image;
+  else if (isVideo(extension)) Component = Video;
+  else Component = Link;
+  Component = <Component className="ternary-fill theme-fill" />;
   // No popover
   if (!title && !description) {
     if (URI)
       return (
-        <a
-          href={URI.replace(/^\/ipfs\//, 'https://ipfs.kleros.io/ipfs/')}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <a href={URI.replace(/^\/ipfs\//, "https://ipfs.kleros.io/ipfs/")} rel="noopener noreferrer" target="_blank">
           {Component}
         </a>
-      )
-    return Component
+      );
+    return Component;
   }
 
   return (
@@ -74,11 +64,7 @@ const Attachment = ({
           <>
             {description}
             <Divider dashed />
-            <StyledIFrame
-              frameBorder="0"
-              src={previewURI}
-              title="Attachment Preview"
-            />
+            <StyledIFrame frameBorder="0" src={previewURI} title="Attachment Preview" />
           </>
         ) : (
           description
@@ -87,32 +73,28 @@ const Attachment = ({
       title={title}
     >
       {URI ? (
-        <a
-          href={URI.replace(/^\/ipfs\//, 'https://ipfs.kleros.io/ipfs/')}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <a href={URI.replace(/^\/ipfs\//, "https://ipfs.kleros.io/ipfs/")} rel="noopener noreferrer" target="_blank">
           {Component}
         </a>
       ) : (
         Component
       )}
     </StyledPopover>
-  )
-}
+  );
+};
 
 Attachment.propTypes = {
-  URI: PropTypes.string,
-  description: PropTypes.string.isRequired,
-  extension: PropTypes.string,
-  previewURI: PropTypes.string,
-  title: PropTypes.string.isRequired
-}
+  URI: t.string,
+  description: t.string,
+  extension: t.string,
+  previewURI: t.string,
+  title: t.string,
+};
 
 Attachment.defaultProps = {
   URI: null,
   extension: null,
-  previewURI: null
-}
+  previewURI: null,
+};
 
-export default Attachment
+export default Attachment;

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -14,7 +14,7 @@ import { ReactComponent as Scales } from "../assets/images/scales.svg";
 import { API } from "../bootstrap/api";
 import { useDataloader, VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
 import web3Salt from "../temp/web3-salt";
-import { range, binaryPermutation } from "../helpers/array";
+import { range, binaryPermutations } from "../helpers/array";
 import Attachment from "./attachment";
 import Breadcrumbs from "./breadcrumbs";
 import CaseRoundHistory from "./case-round-history";
@@ -699,7 +699,7 @@ const deriveVoteFromCommitThroughBruteForce = async ({ commit, salt, rulingOptio
   }
 
   if (rulingOptions.type === "multiple-select") {
-    const permutations = binaryPermutation(numberOfOptions);
+    const permutations = binaryPermutations(numberOfOptions);
 
     let encodedCommittedVote;
 

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -1,46 +1,633 @@
-import * as realitioLibQuestionFormatter from '@realitio/realitio-lib/formatters/question'
-import {
-  Button,
-  Card,
-  Checkbox,
-  Col,
-  DatePicker,
-  Icon,
-  Input,
-  InputNumber,
-  Row,
-  Spin
-} from 'antd'
-import React, { useCallback, useMemo, useState } from 'react'
-import { drizzleReactHooks } from '@drizzle/react-plugin'
-import { API } from '../bootstrap/api'
-import Attachment from './attachment'
-import Breadcrumbs from './breadcrumbs'
-import CaseRoundHistory from './case-round-history'
-import CollapsableCard from './collapsable-card'
-import CourtDrawer from './court-drawer'
-import { ReactComponent as Document } from '../assets/images/document.svg'
-import { ReactComponent as Folder } from '../assets/images/folder.svg'
-import { ReactComponent as Gavel } from '../assets/images/gavel.svg'
-import { ReactComponent as Scales } from '../assets/images/scales.svg'
-import EvidenceTimeline from './evidence-timeline'
-import PropTypes from 'prop-types'
-import ReactMarkdown from 'react-markdown'
-import styled from 'styled-components/macro'
-import { useDataloader, VIEW_ONLY_ADDRESS } from '../bootstrap/dataloader'
-import web3Salt from '../temp/web3-salt'
+import * as realitioLibQuestionFormatter from "@realitio/realitio-lib/formatters/question";
+import { Alert, Button, Card, Checkbox, Col, DatePicker, Icon, Input, InputNumber, Row, Spin } from "antd";
+import React, { useCallback, useMemo, useState } from "react";
+import Web3 from "web3";
+import { drizzleReactHooks } from "@drizzle/react-plugin";
+import createPersistedState from "use-persisted-state";
+import { API } from "../bootstrap/api";
+import Attachment from "./attachment";
+import Breadcrumbs from "./breadcrumbs";
+import CaseRoundHistory from "./case-round-history";
+import CollapsableCard from "./collapsable-card";
+import CourtDrawer from "./court-drawer";
+import { ReactComponent as Document } from "../assets/images/document.svg";
+import { ReactComponent as Folder } from "../assets/images/folder.svg";
+import { ReactComponent as Gavel } from "../assets/images/gavel.svg";
+import { ReactComponent as Scales } from "../assets/images/scales.svg";
+import EvidenceTimeline from "./evidence-timeline";
+import PropTypes from "prop-types";
+import ReactMarkdown from "react-markdown";
+import styled from "styled-components/macro";
+import { useDataloader, VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
+import web3Salt from "../temp/web3-salt";
 
-const { useDrizzle, useDrizzleState } = drizzleReactHooks
+const { useDrizzle, useDrizzleState } = drizzleReactHooks;
 
-realitioLibQuestionFormatter.minNumber = realitioLibQuestionFormatter.minNumber.bind(
-  {
-    maxNumber: (...args) => {
-      const result = realitioLibQuestionFormatter.maxNumber(...args)
-      result.neg = result.negated
-      return result
+const { toBN } = Web3.utils;
+
+realitioLibQuestionFormatter.minNumber = realitioLibQuestionFormatter.minNumber.bind({
+  maxNumber: (...args) => {
+    const result = realitioLibQuestionFormatter.maxNumber(...args);
+    result.neg = result.negated;
+    return result;
+  },
+});
+
+export default function CaseDetailsCard({ ID }) {
+  const { drizzle, useCacheCall, useCacheEvents, useCacheSend } = useDrizzle();
+  const drizzleState = useDrizzleState((drizzleState) => ({
+    account: drizzleState.accounts[0] || VIEW_ONLY_ADDRESS,
+  }));
+  const loadPolicy = useDataloader.loadPolicy();
+  const getMetaEvidence = useDataloader.getMetaEvidence();
+  const getEvidence = useDataloader.getEvidence();
+  const [activeSubcourtID, setActiveSubcourtID] = useState();
+  const [justification, setJustification] = useState();
+  const [complexRuling, setComplexRuling] = useState();
+  const dispute = useCacheCall("KlerosLiquid", "disputes", ID);
+  const dispute2 = useCacheCall("KlerosLiquid", "getDispute", ID);
+  const draws = useCacheEvents(
+    "KlerosLiquid",
+    "Draw",
+    useMemo(
+      () => ({
+        filter: { _address: drizzleState.account, _disputeID: ID },
+        fromBlock: process.env.REACT_APP_KLEROS_LIQUID_BLOCK_NUMBER,
+      }),
+      [drizzleState.account, ID]
+    )
+  );
+  const votesData = useCacheCall(["KlerosLiquid"], (call) => {
+    let votesData = { loading: true };
+    const currentRuling = call("KlerosLiquid", "currentRuling", ID);
+    if (dispute && dispute2 && draws) {
+      const drawnInCurrentRound =
+        draws.length > 0 && Number(draws[draws.length - 1].returnValues._appeal) === dispute2.votesLengths.length - 1;
+      const vote =
+        drawnInCurrentRound &&
+        call(
+          "KlerosLiquid",
+          "getVote",
+          ID,
+          draws[draws.length - 1].returnValues._appeal,
+          draws[draws.length - 1].returnValues._voteID
+        );
+      const subcourt = drawnInCurrentRound && call("KlerosLiquid", "courts", dispute.subcourtID);
+      if (!drawnInCurrentRound || (vote && subcourt)) {
+        const committed =
+          drawnInCurrentRound && vote.commit !== "0x0000000000000000000000000000000000000000000000000000000000000000";
+        votesData = draws.reduce(
+          (acc, d) => {
+            if (Number(d.returnValues._appeal) === dispute2.votesLengths.length - 1)
+              acc.voteIDs.push(d.returnValues._voteID);
+            return acc;
+          },
+          {
+            canVote:
+              drawnInCurrentRound &&
+              ((dispute.period === "1" && !committed) ||
+                (dispute.period === "2" && (!subcourt.hiddenVotes || committed) && !vote.voted)),
+            committed,
+            currentRuling,
+            drawnInCurrentRound,
+            loading: !currentRuling,
+            voteIDs: [],
+            voted: vote.voted && vote.choice,
+          }
+        );
+      }
     }
+    return votesData;
+  });
+  const subcourts = useCacheCall(["PolicyRegistry", "KlerosLiquid"], (call) => {
+    if (dispute) {
+      const subcourts = [];
+      let nextID = dispute.subcourtID;
+      while (!subcourts.length || subcourts[subcourts.length - 1].ID !== nextID) {
+        const subcourt = {
+          ID: nextID,
+          hiddenVotes: undefined,
+          name: undefined,
+        };
+        const policy = call("PolicyRegistry", "policies", subcourt.ID);
+        if (policy !== undefined) {
+          const policyJSON = loadPolicy(policy);
+          if (policyJSON) subcourt.name = policyJSON.name;
+        }
+        const _subcourt = call("KlerosLiquid", "courts", subcourt.ID);
+        if (_subcourt) {
+          nextID = _subcourt.parent;
+          subcourt.hiddenVotes = _subcourt.hiddenVotes;
+        }
+        if (subcourt.name === undefined || !_subcourt) return undefined;
+        subcourts.push(subcourt);
+      }
+      return subcourts.reverse();
+    }
+  });
+  let metaEvidence;
+  let evidence;
+  if (dispute) {
+    if (dispute.ruled) {
+      metaEvidence = getMetaEvidence(dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID, {
+        strictHashes: false,
+      });
+    } else {
+      metaEvidence = getMetaEvidence(dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
+    }
+
+    evidence = getEvidence(dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
   }
-)
+  const { send: sendCommit, status: sendCommitStatus } = useCacheSend("KlerosLiquid", "castCommit");
+  const { send: sendVote, status: sendVoteStatus } = useCacheSend("KlerosLiquid", "castVote");
+  const onJustificationChange = useCallback(({ currentTarget: { value } }) => setJustification(value), []);
+  const disabledDate = useCallback(
+    (date) =>
+      realitioLibQuestionFormatter
+        .maxNumber({
+          decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+          type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+        })
+        .lte(date.unix() + 1),
+    [metaEvidence]
+  );
+
+  const { account } = drizzleState;
+  const { web3 } = drizzle;
+  const useStoredCommitedVote = React.useMemo(() => createPersistedState(`@kleros/court/${account}/${ID}/vote`), [
+    ID,
+    account,
+  ]);
+  const [committedVote, setCommittedVote] = useStoredCommitedVote();
+
+  const sendOrRevealVote = useCallback(
+    async (choice) => {
+      API.putJustifications(web3, account, {
+        appeal: dispute2.votesLengths.length - 1,
+        disputeID: ID,
+        justification,
+        voteIDs: votesData.voteIDs,
+      });
+
+      sendVote(
+        ID,
+        votesData.voteIDs,
+        choice,
+        subcourts[subcourts.length - 1].hiddenVotes
+          ? await web3Salt(
+              web3,
+              account,
+              "Please sign this message to secure your vote. This is unrelated from your main Ethereum account and will not be able to send any transactions.",
+              ID,
+              dispute2.votesLengths.length - 1
+            )
+          : 0
+      );
+    },
+    [dispute2, votesData, web3, account, subcourts, ID, justification, sendVote]
+  );
+
+  const onRevealClick = useCallback(() => {
+    sendOrRevealVote(committedVote);
+  }, [committedVote, sendOrRevealVote]);
+
+  const onVoteClick = useCallback(
+    async ({ currentTarget: { id } }) => {
+      let choice;
+      const typeSwitch =
+        id !== "0" && metaEvidence.metaEvidenceJSON.rulingOptions && metaEvidence.metaEvidenceJSON.rulingOptions.type;
+      switch (typeSwitch) {
+        case "multiple-select":
+          choice = metaEvidence.metaEvidenceJSON.rulingOptions.titles
+            ? metaEvidence.metaEvidenceJSON.rulingOptions.titles.map((t) => complexRuling.includes(t))
+            : [];
+          break;
+        case "datetime":
+          choice = complexRuling.unix();
+          break;
+        case "uint":
+          choice = complexRuling;
+          break;
+        default:
+          choice = id;
+          break;
+      }
+      switch (typeSwitch) {
+        case "multiple-select":
+        case "datetime":
+        case "uint":
+          choice = realitioLibQuestionFormatter.answerToBytes32(choice, {
+            decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+            type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+          });
+          choice = realitioLibQuestionFormatter.padToBytes32(
+            drizzle.web3.utils.toBN(choice).add(drizzle.web3.utils.toBN("1")).toString(16)
+          );
+          break;
+        default:
+          break;
+      }
+      if (dispute.period === "1") {
+        sendCommit(
+          ID,
+          votesData.voteIDs,
+          drizzle.web3.utils.soliditySha3(
+            choice,
+            await web3Salt(
+              drizzle.web3,
+              drizzleState.account,
+              "Please sign this message to secure your vote. This is unrelated from your main Ethereum account and will not be able to send any transactions.",
+              ID,
+              dispute2.votesLengths.length - 1
+            )
+          )
+        );
+        setCommittedVote(choice);
+      } else {
+        sendOrRevealVote(choice);
+      }
+    },
+    [
+      setCommittedVote,
+      sendCommit,
+      metaEvidence,
+      complexRuling,
+      dispute,
+      ID,
+      votesData.voteIDs,
+      drizzle.web3,
+      drizzleState.account,
+      dispute2,
+      sendOrRevealVote,
+    ]
+  );
+  const metaEvidenceActions = useMemo(() => {
+    if (metaEvidence) {
+      const actions = [];
+      if (metaEvidence.metaEvidenceJSON.fileURI)
+        actions.push(
+          <Attachment
+            URI={metaEvidence.metaEvidenceJSON.fileURI}
+            description="This is the primary file uploaded with the dispute."
+            extension={metaEvidence.metaEvidenceJSON.fileTypeExtension}
+            title="Main File"
+          />
+        );
+      actions.push(
+        <StyledInnerCardActionsTitleDiv className="ternary-color theme-color">
+          Primary Documents
+        </StyledInnerCardActionsTitleDiv>
+      );
+      return actions;
+    }
+  }, [metaEvidence]);
+  return (
+    <StyledCard
+      actions={[
+        <Spin
+          key="main"
+          spinning={
+            votesData.loading ||
+            !subcourts ||
+            !metaEvidence ||
+            sendCommitStatus === "pending" ||
+            sendVoteStatus === "pending"
+          }
+        >
+          {!votesData.loading && subcourts && metaEvidence ? (
+            <>
+              <StyledActionsDiv className="secondary-linear-background theme-linear-background">
+                {dispute.period !== "2" ? <GavalLarge /> : ""}
+                {votesData.drawnInCurrentRound
+                  ? votesData.canVote
+                    ? metaEvidence.metaEvidenceJSON.question
+                      ? metaEvidence.metaEvidenceJSON.question
+                      : "What is your decision?"
+                    : votesData.voted
+                    ? `You voted for: ${
+                        votesData.voted === "0"
+                          ? "Refuse to Arbitrate"
+                          : (metaEvidence.metaEvidenceJSON.rulingOptions &&
+                              realitioLibQuestionFormatter.getAnswerString(
+                                {
+                                  decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+                                  outcomes: metaEvidence.metaEvidenceJSON.rulingOptions.titles,
+                                  type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+                                },
+                                realitioLibQuestionFormatter.padToBytes32(
+                                  drizzle.web3.utils
+                                    .toBN(votesData.voted)
+                                    .sub(drizzle.web3.utils.toBN("1"))
+                                    .toString(16)
+                                )
+                              )) ||
+                            "Unknown Choice"
+                      }.`
+                    : dispute.period === "0"
+                    ? "Waiting for evidence."
+                    : dispute.period === "1"
+                    ? "Waiting to reveal your vote."
+                    : subcourts[subcourts.length - 1].hiddenVotes
+                    ? votesData.committed
+                      ? "You did not reveal your vote."
+                      : "You did not commit a vote."
+                    : "You did not cast a vote."
+                  : "You were not drawn in the current round."}
+                {dispute.period === "4" && (
+                  <SecondaryActionText>
+                    {` The winner in this case was "${
+                      votesData.currentRuling === "0"
+                        ? "Refuse to Arbitrate"
+                        : (metaEvidence.metaEvidenceJSON.rulingOptions &&
+                            realitioLibQuestionFormatter.getAnswerString(
+                              {
+                                decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+                                outcomes: metaEvidence.metaEvidenceJSON.rulingOptions.titles,
+                                type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+                              },
+                              realitioLibQuestionFormatter.padToBytes32(
+                                drizzle.web3.utils
+                                  .toBN(votesData.currentRuling)
+                                  .sub(drizzle.web3.utils.toBN("1"))
+                                  .toString(16)
+                              )
+                            )) ||
+                          "Unknown Choice"
+                    }".`}
+                  </SecondaryActionText>
+                )}
+                {votesData.committed ? (
+                  committedVote !== undefined ? (
+                    <SecondaryActionText>
+                      You committed to:{" "}
+                      {votesData.voted === "0"
+                        ? "Refuse to Arbitrate"
+                        : (metaEvidence.metaEvidenceJSON.rulingOptions &&
+                            realitioLibQuestionFormatter.getAnswerString(
+                              {
+                                decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+                                outcomes: metaEvidence.metaEvidenceJSON.rulingOptions.titles,
+                                type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+                              },
+                              realitioLibQuestionFormatter.padToBytes32(toBN(committedVote).sub(toBN("1")).toString(16))
+                            )) ||
+                          "Unknown Choice"}
+                      .
+                    </SecondaryActionText>
+                  ) : (
+                    <Alert
+                      showIcon
+                      type="warning"
+                      message="Could not find your commited vote"
+                      description="You probably commited to your vote from another device. You will need to manually select the voted option(s) and submit it."
+                      css={`
+                        text-align: left;
+                        margin-top: 2rem;
+                      `}
+                    />
+                  )
+                ) : null}
+                {votesData.canVote && dispute.period === "2" && (
+                  <StyledInputTextArea
+                    onChange={onJustificationChange}
+                    placeholder="Justify your vote here..."
+                    value={justification}
+                  />
+                )}
+                {Number(dispute.period) < 3 && metaEvidence.metaEvidenceJSON.rulingOptions ? (
+                  votesData.committed && committedVote !== undefined ? (
+                    <StyledButtonsDiv>
+                      <StyledButton onClick={onRevealClick} size="large" type="primary">
+                        Reveal Vote
+                      </StyledButton>
+                    </StyledButtonsDiv>
+                  ) : (
+                    <>
+                      {metaEvidence.metaEvidenceJSON.rulingOptions.type !== "single-select" && (
+                        <StyledButtonsDiv>
+                          {metaEvidence.metaEvidenceJSON.rulingOptions.type === "multiple-select" ? (
+                            <Checkbox.Group
+                              disabled={!votesData.canVote}
+                              name="ruling"
+                              onChange={setComplexRuling}
+                              options={
+                                metaEvidence.metaEvidenceJSON.rulingOptions.titles &&
+                                metaEvidence.metaEvidenceJSON.rulingOptions.titles.slice(0, 255)
+                              }
+                              value={complexRuling}
+                            />
+                          ) : metaEvidence.metaEvidenceJSON.rulingOptions.type === "datetime" ? (
+                            <DatePicker
+                              disabled={!votesData.canVote}
+                              disabledDate={disabledDate}
+                              onChange={setComplexRuling}
+                              showTime
+                              size="large"
+                              value={complexRuling}
+                            />
+                          ) : (
+                            <InputNumber
+                              disabled={!votesData.canVote}
+                              max={Number(
+                                realitioLibQuestionFormatter
+                                  .maxNumber({
+                                    decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+                                    type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+                                  })
+                                  .minus(1)
+                              )}
+                              min={Number(
+                                realitioLibQuestionFormatter.minNumber({
+                                  decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+                                  type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+                                })
+                              )}
+                              onChange={setComplexRuling}
+                              precision={metaEvidence.metaEvidenceJSON.rulingOptions.precision}
+                              size="large"
+                              value={complexRuling}
+                            />
+                          )}
+                        </StyledButtonsDiv>
+                      )}
+                      <StyledButtonsDiv>
+                        {metaEvidence.metaEvidenceJSON.rulingOptions.type === "single-select" ? (
+                          metaEvidence.metaEvidenceJSON.rulingOptions.titles &&
+                          metaEvidence.metaEvidenceJSON.rulingOptions.titles.slice(0, 2 ** 256 - 1).map((t, i) => (
+                            <StyledButton
+                              disabled={!votesData.canVote}
+                              id={i + 1}
+                              key={t}
+                              onClick={onVoteClick}
+                              size="large"
+                              type="primary"
+                            >
+                              {t}
+                            </StyledButton>
+                          ))
+                        ) : (
+                          <StyledButton
+                            disabled={!votesData.canVote || !complexRuling}
+                            onClick={onVoteClick}
+                            size="large"
+                            type="primary"
+                          >
+                            Submit
+                          </StyledButton>
+                        )}
+                      </StyledButtonsDiv>
+                    </>
+                  )
+                ) : null}
+              </StyledActionsDiv>
+              <StyledDiv className="secondary-background theme-background" style={{ display: "inherit" }}>
+                {Number(dispute.period) < "3" && (
+                  <Button
+                    disabled={!votesData.canVote}
+                    ghost={votesData.canVote}
+                    id={0}
+                    onClick={onVoteClick}
+                    size="large"
+                  >
+                    Refuse to Arbitrate
+                  </Button>
+                )}
+              </StyledDiv>
+            </>
+          ) : (
+            <StyledDiv className="secondary-linear-background theme-linear-background" />
+          )}
+        </Spin>,
+      ]}
+      extra={
+        <StyledPoliciesButton
+          onClick={useCallback(() => dispute && setActiveSubcourtID(dispute.subcourtID), [dispute])}
+        >
+          <StyledDocument /> Policies
+        </StyledPoliciesButton>
+      }
+      loading={!metaEvidence}
+      title={
+        <>
+          {metaEvidence && metaEvidence.metaEvidenceJSON.title}
+          {subcourts && <StyledBreadcrumbs breadcrumbs={subcourts.map((s) => s.name)} />}
+        </>
+      }
+    >
+      {metaEvidence && (
+        <>
+          <Row>
+            <Col span={24}>
+              <StyledInnerCard actions={metaEvidenceActions}>
+                <ReactMarkdown source={metaEvidence.metaEvidenceJSON.description} />
+                {metaEvidence.metaEvidenceJSON.evidenceDisplayInterfaceURI && (
+                  <StyledIFrame
+                    frameBorder="0"
+                    src={`${metaEvidence.metaEvidenceJSON.evidenceDisplayInterfaceURI.replace(
+                      /^\/ipfs\//,
+                      "https://ipfs.kleros.io/ipfs/"
+                    )}?${encodeURIComponent(
+                      JSON.stringify({
+                        arbitrableContractAddress: dispute.arbitrated,
+                        arbitratorContractAddress: drizzle.contracts.KlerosLiquid.address,
+                        disputeID: ID,
+                      })
+                    )}`}
+                    title="MetaEvidence Display"
+                    height={metaEvidence.metaEvidenceJSON.evidenceDisplayHeight || "215px"}
+                  />
+                )}
+                {metaEvidence.metaEvidenceJSON.arbitrableInterfaceURI && (
+                  <ArbitrableInterfaceDiv>
+                    <a
+                      href={metaEvidence.metaEvidenceJSON.arbitrableInterfaceURI}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Icon type="double-right" style={{ marginRight: "5px" }} />
+                      Go to the Arbitrable Application
+                    </a>
+                  </ArbitrableInterfaceDiv>
+                )}
+                {ID === "302" ? (
+                  <ArbitrableInterfaceDiv>
+                    This realitio dispute has been created by Omen, we advise you to read the{" "}
+                    <a target="_blank" rel="noopener noreferrer" href={"https://omen.eth.link/rules.pdf"}>
+                      Omen Rules
+                    </a>{" "}
+                    and consult the evidence provided in the{" "}
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href={"https://omen.eth.link/#/0xffbc624070cb014420a6f7547fd05dfe635e2db2"}
+                    >
+                      Market Comments.
+                    </a>
+                  </ArbitrableInterfaceDiv>
+                ) : null}
+                {ID === "532" ? (
+                  <ArbitrableInterfaceDiv>
+                    This realitio dispute has been created by Omen, we advise you to read the{" "}
+                    <a target="_blank" rel="noopener noreferrer" href={"https://omen.eth.link/rules.pdf"}>
+                      Omen Rules
+                    </a>{" "}
+                    and consult the evidence provided in the{" "}
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href={"https://omen.eth.link/#/0x95b2271039b020aba31b933039e042b60b063800"}
+                    >
+                      Market Comments.
+                    </a>
+                  </ArbitrableInterfaceDiv>
+                ) : null}
+              </StyledInnerCard>
+            </Col>
+          </Row>
+          <CollapsableCard
+            title={
+              <>
+                <Folder /> {`Evidence (${evidence ? evidence.length : 0})`}
+              </>
+            }
+          >
+            <EvidenceTimeline
+              evidence={evidence}
+              metaEvidence={metaEvidence}
+              ruling={dispute.period === "4" ? votesData.currentRuling : null}
+            />
+          </CollapsableCard>
+          {dispute2 &&
+            metaEvidence &&
+            metaEvidence.metaEvidenceJSON.rulingOptions &&
+            metaEvidence.metaEvidenceJSON.rulingOptions.type === "single-select" && (
+              <CollapsableCard
+                title={
+                  <>
+                    <Scales /> Dispute History
+                  </>
+                }
+              >
+                <CaseRoundHistory
+                  ID={ID}
+                  dispute={{
+                    ...dispute2,
+                    ...dispute,
+                  }}
+                  ruling={dispute.period === "4" ? votesData.currentRuling : null}
+                />
+              </CollapsableCard>
+            )}
+        </>
+      )}
+      {activeSubcourtID !== undefined && <CourtDrawer ID={activeSubcourtID} onClose={setActiveSubcourtID} />}
+    </StyledCard>
+  );
+}
+
+CaseDetailsCard.propTypes = {
+  ID: PropTypes.string.isRequired,
+};
 
 const StyledCard = styled(Card)`
   border-radius: 12px;
@@ -84,7 +671,7 @@ const StyledCard = styled(Card)`
       }
     }
   }
-`
+`;
 const StyledDiv = styled.div`
   align-items: center;
   color: white;
@@ -92,14 +679,14 @@ const StyledDiv = styled.div`
   flex-direction: column;
   font-size: 24px;
   padding: 34px 10px;
-`
+`;
 const StyledActionsDiv = styled(StyledDiv)`
   min-height: 250px;
   overflow: hidden;
-`
+`;
 const SecondaryActionText = styled.div`
   margin-top: 30px;
-`
+`;
 const StyledInputTextArea = styled(Input.TextArea)`
   background: rgba(255, 255, 255, 0.3);
   border: none;
@@ -107,7 +694,7 @@ const StyledInputTextArea = styled(Input.TextArea)`
   height: 91px !important;
   margin: 24px 0;
   width: 70%;
-`
+`;
 const StyledButtonsDiv = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -121,11 +708,11 @@ const StyledButtonsDiv = styled.div`
   .ant-checkbox-group-item.ant-checkbox-wrapper span {
     color: white;
   }
-`
+`;
 const StyledButton = styled(Button)`
   flex: 0 0 35%;
   margin: 20px 5px 15px;
-`
+`;
 const StyledPoliciesButton = styled(Button)`
   border: 1px solid #4d00b4;
   border-radius: 3px;
@@ -133,14 +720,14 @@ const StyledPoliciesButton = styled(Button)`
   color: #4d00b4;
   padding-left: 40px;
   position: relative;
-`
+`;
 const GavalLarge = styled(Gavel)`
   height: 150px;
   opacity: 0.15;
   position: absolute;
   top: 50px;
   width: 150px;
-`
+`;
 const StyledDocument = styled(Document)`
   height: 18px;
   left: 17px;
@@ -151,13 +738,13 @@ const StyledDocument = styled(Document)`
   path {
     fill: #4d00b4;
   }
-`
+`;
 const StyledBreadcrumbs = styled(Breadcrumbs)`
   bottom: -20px;
   font-size: 10px;
   left: 0;
   position: absolute;
-`
+`;
 const StyledInnerCard = styled(Card)`
   border: 1px solid #d09cff;
   border-radius: 3px;
@@ -169,6 +756,8 @@ const StyledInnerCard = styled(Card)`
     &-head {
       margin: 0 21px 0 17px;
       padding: 0;
+
+      &-title {
 
       &-title {
         align-items: center;
@@ -217,10 +806,10 @@ const StyledInnerCard = styled(Card)`
       }
     }
   }
-`
+`;
 const StyledIFrame = styled.iframe`
   width: 100%;
-`
+`;
 const StyledInnerCardActionsTitleDiv = styled.div`
   background: linear-gradient(204.14deg, #ffffff -6.48%, #f5f1fd 45.52%);
   border-radius: 6px 6px 0 0;
@@ -235,7 +824,7 @@ const StyledInnerCardActionsTitleDiv = styled.div`
   @media (max-width: 500px) {
     left: -40px;
   }
-`
+`;
 const ArbitrableInterfaceDiv = styled.div`
   border-top: 1px solid #d09cff;
   font-size: 18px;
@@ -244,663 +833,4 @@ const ArbitrableInterfaceDiv = styled.div`
   a {
     color: #4d00b4;
   }
-`
-
-const CaseDetailsCard = ({ ID }) => {
-  const { drizzle, useCacheCall, useCacheEvents, useCacheSend } = useDrizzle()
-  const drizzleState = useDrizzleState(drizzleState => ({
-    account: drizzleState.accounts[0] || VIEW_ONLY_ADDRESS
-  }))
-  const loadPolicy = useDataloader.loadPolicy()
-  const getMetaEvidence = useDataloader.getMetaEvidence()
-  const getEvidence = useDataloader.getEvidence()
-  const [activeSubcourtID, setActiveSubcourtID] = useState()
-  const [justification, setJustification] = useState()
-  const [complexRuling, setComplexRuling] = useState()
-  const dispute = useCacheCall('KlerosLiquid', 'disputes', ID)
-  const dispute2 = useCacheCall('KlerosLiquid', 'getDispute', ID)
-  const draws = useCacheEvents(
-    'KlerosLiquid',
-    'Draw',
-    useMemo(
-      () => ({
-        filter: { _address: drizzleState.account, _disputeID: ID },
-        fromBlock: process.env.REACT_APP_KLEROS_LIQUID_BLOCK_NUMBER
-      }),
-      [drizzleState.account, ID]
-    )
-  )
-  const votesData = useCacheCall(['KlerosLiquid'], call => {
-    let votesData = { loading: true }
-    const currentRuling = call('KlerosLiquid', 'currentRuling', ID)
-    if (dispute && dispute2 && draws) {
-      const drawnInCurrentRound =
-        draws.length > 0 &&
-        Number(draws[draws.length - 1].returnValues._appeal) ===
-          dispute2.votesLengths.length - 1
-      const vote =
-        drawnInCurrentRound &&
-        call(
-          'KlerosLiquid',
-          'getVote',
-          ID,
-          draws[draws.length - 1].returnValues._appeal,
-          draws[draws.length - 1].returnValues._voteID
-        )
-      const subcourt =
-        drawnInCurrentRound &&
-        call('KlerosLiquid', 'courts', dispute.subcourtID)
-      if (!drawnInCurrentRound || (vote && subcourt)) {
-        const committed =
-          drawnInCurrentRound &&
-          vote.commit !==
-            '0x0000000000000000000000000000000000000000000000000000000000000000'
-        votesData = draws.reduce(
-          (acc, d) => {
-            if (
-              Number(d.returnValues._appeal) ===
-              dispute2.votesLengths.length - 1
-            )
-              acc.voteIDs.push(d.returnValues._voteID)
-            return acc
-          },
-          {
-            canVote:
-              drawnInCurrentRound &&
-              ((dispute.period === '1' && !committed) ||
-                (dispute.period === '2' &&
-                  (!subcourt.hiddenVotes || committed) &&
-                  !vote.voted)),
-            committed,
-            currentRuling,
-            drawnInCurrentRound,
-            loading: !currentRuling,
-            voteIDs: [],
-            voted: vote.voted && vote.choice
-          }
-        )
-      }
-    }
-    return votesData
-  })
-  const subcourts = useCacheCall(['PolicyRegistry', 'KlerosLiquid'], call => {
-    if (dispute) {
-      const subcourts = []
-      let nextID = dispute.subcourtID
-      while (
-        !subcourts.length ||
-        subcourts[subcourts.length - 1].ID !== nextID
-      ) {
-        const subcourt = {
-          ID: nextID,
-          hiddenVotes: undefined,
-          name: undefined
-        }
-        const policy = call('PolicyRegistry', 'policies', subcourt.ID)
-        if (policy !== undefined) {
-          const policyJSON = loadPolicy(policy)
-          if (policyJSON) subcourt.name = policyJSON.name
-        }
-        const _subcourt = call('KlerosLiquid', 'courts', subcourt.ID)
-        if (_subcourt) {
-          nextID = _subcourt.parent
-          subcourt.hiddenVotes = _subcourt.hiddenVotes
-        }
-        if (subcourt.name === undefined || !_subcourt) return undefined
-        subcourts.push(subcourt)
-      }
-      return subcourts.reverse()
-    }
-  })
-  let metaEvidence
-  let evidence
-  if (dispute) {
-    if (dispute.ruled) {
-      metaEvidence = getMetaEvidence(
-        dispute.arbitrated,
-        drizzle.contracts.KlerosLiquid.address,
-        ID,
-        {
-          strictHashes: false
-        }
-      )
-    } else {
-      metaEvidence = getMetaEvidence(
-        dispute.arbitrated,
-        drizzle.contracts.KlerosLiquid.address,
-        ID
-      )
-    }
-
-    evidence = getEvidence(
-      dispute.arbitrated,
-      drizzle.contracts.KlerosLiquid.address,
-      ID
-    )
-  }
-  const { send: sendCommit, status: sendCommitStatus } = useCacheSend(
-    'KlerosLiquid',
-    'castCommit'
-  )
-  const { send: sendVote, status: sendVoteStatus } = useCacheSend(
-    'KlerosLiquid',
-    'castVote'
-  )
-  const onJustificationChange = useCallback(
-    ({ currentTarget: { value } }) => setJustification(value),
-    []
-  )
-  const disabledDate = useCallback(
-    date =>
-      realitioLibQuestionFormatter
-        .maxNumber({
-          decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
-          type: metaEvidence.metaEvidenceJSON.rulingOptions.type
-        })
-        .lte(date.unix() + 1),
-    [
-      metaEvidence &&
-        metaEvidence.metaEvidenceJSON.rulingOptions &&
-        metaEvidence.metaEvidenceJSON.rulingOptions.precision,
-      metaEvidence &&
-        metaEvidence.metaEvidenceJSON.rulingOptions &&
-        metaEvidence.metaEvidenceJSON.rulingOptions.type
-    ]
-  )
-  const onVoteClick = useCallback(
-    async ({ currentTarget: { id } }) => {
-      let choice
-      const typeSwitch =
-        id !== '0' &&
-        metaEvidence.metaEvidenceJSON.rulingOptions &&
-        metaEvidence.metaEvidenceJSON.rulingOptions.type
-      switch (typeSwitch) {
-        case 'multiple-select':
-          choice = metaEvidence.metaEvidenceJSON.rulingOptions.titles
-            ? metaEvidence.metaEvidenceJSON.rulingOptions.titles.map(t =>
-                complexRuling.includes(t)
-              )
-            : []
-          break
-        case 'datetime':
-          choice = complexRuling.unix()
-          break
-        case 'uint':
-          choice = complexRuling
-          break
-        default:
-          choice = id
-          break
-      }
-      switch (typeSwitch) {
-        case 'multiple-select':
-        case 'datetime':
-        case 'uint':
-          choice = realitioLibQuestionFormatter.answerToBytes32(choice, {
-            decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
-            type: metaEvidence.metaEvidenceJSON.rulingOptions.type
-          })
-          choice = realitioLibQuestionFormatter.padToBytes32(
-            drizzle.web3.utils
-              .toBN(choice)
-              .add(drizzle.web3.utils.toBN('1'))
-              .toString(16)
-          )
-          break
-        default:
-          break
-      }
-      if (dispute.period === '1')
-        sendCommit(
-          ID,
-          votesData.voteIDs,
-          drizzle.web3.utils.soliditySha3(
-            choice,
-            await web3Salt(
-              drizzle.web3,
-              drizzleState.account,
-              'Please sign this message to secure your vote. This is unrelated from your main Ethereum account and will not be able to send any transactions.',
-              ID,
-              dispute2.votesLengths.length - 1
-            )
-          )
-        )
-      else {
-        API.putJustifications(drizzle.web3, drizzleState.account, {
-          appeal: dispute2.votesLengths.length - 1,
-          disputeID: ID,
-          justification,
-          voteIDs: votesData.voteIDs
-        })
-
-        sendVote(
-          ID,
-          votesData.voteIDs,
-          choice,
-          subcourts[subcourts.length - 1].hiddenVotes
-            ? await web3Salt(
-                drizzle.web3,
-                drizzleState.account,
-                'Please sign this message to secure your vote. This is unrelated from your main Ethereum account and will not be able to send any transactions.',
-                ID,
-                dispute2.votesLengths.length - 1
-              )
-            : 0
-        )
-      }
-    },
-    [
-      metaEvidence,
-      complexRuling,
-      dispute && dispute.period,
-      ID,
-      votesData.voteIDs,
-      drizzle.web3,
-      drizzleState.account,
-      dispute2 && dispute2.votesLengths.length,
-      subcourts && subcourts[subcourts.length - 1].hiddenVotes,
-      justification
-    ]
-  )
-  const metaEvidenceActions = useMemo(() => {
-    if (metaEvidence) {
-      const actions = []
-      if (metaEvidence.metaEvidenceJSON.fileURI)
-        actions.push(
-          <Attachment
-            URI={metaEvidence.metaEvidenceJSON.fileURI}
-            description="This is the primary file uploaded with the dispute."
-            extension={metaEvidence.metaEvidenceJSON.fileTypeExtension}
-            title="Main File"
-          />
-        )
-      actions.push(
-        <StyledInnerCardActionsTitleDiv className="ternary-color theme-color">
-          Primary Documents
-        </StyledInnerCardActionsTitleDiv>
-      )
-      return actions
-    }
-  }, [metaEvidence])
-  return (
-    <StyledCard
-      actions={useMemo(() => [
-        <Spin
-          spinning={
-            votesData.loading ||
-            !subcourts ||
-            !metaEvidence ||
-            sendCommitStatus === 'pending' ||
-            sendVoteStatus === 'pending'
-          }
-        >
-          {!votesData.loading && subcourts && metaEvidence ? (
-            <>
-              <StyledActionsDiv className="secondary-linear-background theme-linear-background">
-                {dispute.period !== '2' ? <GavalLarge /> : ''}
-                {votesData.drawnInCurrentRound
-                  ? votesData.canVote
-                    ? metaEvidence.metaEvidenceJSON.question
-                      ? metaEvidence.metaEvidenceJSON.question
-                      : 'What is your decision?'
-                    : votesData.voted
-                    ? `You voted for: ${
-                        votesData.voted === '0'
-                          ? 'Refuse to Arbitrate'
-                          : (metaEvidence.metaEvidenceJSON.rulingOptions &&
-                              realitioLibQuestionFormatter.getAnswerString(
-                                {
-                                  decimals:
-                                    metaEvidence.metaEvidenceJSON.rulingOptions
-                                      .precision,
-                                  outcomes:
-                                    metaEvidence.metaEvidenceJSON.rulingOptions
-                                      .titles,
-                                  type:
-                                    metaEvidence.metaEvidenceJSON.rulingOptions
-                                      .type
-                                },
-                                realitioLibQuestionFormatter.padToBytes32(
-                                  drizzle.web3.utils
-                                    .toBN(votesData.voted)
-                                    .sub(drizzle.web3.utils.toBN('1'))
-                                    .toString(16)
-                                )
-                              )) ||
-                            'Unknown Choice'
-                      }.`
-                    : dispute.period === '0'
-                    ? 'Waiting for evidence.'
-                    : dispute.period === '1'
-                    ? 'Waiting to reveal your vote.'
-                    : subcourts[subcourts.length - 1].hiddenVotes
-                    ? votesData.committed
-                      ? 'You did not reveal your vote.'
-                      : 'You did not commit a vote.'
-                    : 'You did not cast a vote.'
-                  : 'You were not drawn in the current round.'}
-                {dispute.period === '4' && (
-                  <SecondaryActionText>
-                    {` The winner in this case was "${
-                      votesData.currentRuling === '0'
-                        ? 'Refuse to Arbitrate'
-                        : (metaEvidence.metaEvidenceJSON.rulingOptions &&
-                            realitioLibQuestionFormatter.getAnswerString(
-                              {
-                                decimals:
-                                  metaEvidence.metaEvidenceJSON.rulingOptions
-                                    .precision,
-                                outcomes:
-                                  metaEvidence.metaEvidenceJSON.rulingOptions
-                                    .titles,
-                                type:
-                                  metaEvidence.metaEvidenceJSON.rulingOptions
-                                    .type
-                              },
-                              realitioLibQuestionFormatter.padToBytes32(
-                                drizzle.web3.utils
-                                  .toBN(votesData.currentRuling)
-                                  .sub(drizzle.web3.utils.toBN('1'))
-                                  .toString(16)
-                              )
-                            )) ||
-                          'Unknown Choice'
-                    }".`}
-                  </SecondaryActionText>
-                )}
-                {votesData.canVote && dispute.period === '2' && (
-                  <StyledInputTextArea
-                    onChange={onJustificationChange}
-                    placeholder="Justify your vote here..."
-                    value={justification}
-                  />
-                )}
-                {Number(dispute.period) < 3 &&
-                  metaEvidence.metaEvidenceJSON.rulingOptions && (
-                    <>
-                      {metaEvidence.metaEvidenceJSON.rulingOptions.type !==
-                        'single-select' && (
-                        <StyledButtonsDiv>
-                          {metaEvidence.metaEvidenceJSON.rulingOptions.type ===
-                          'multiple-select' ? (
-                            <Checkbox.Group
-                              disabled={!votesData.canVote}
-                              name="ruling"
-                              onChange={setComplexRuling}
-                              options={
-                                metaEvidence.metaEvidenceJSON.rulingOptions
-                                  .titles &&
-                                metaEvidence.metaEvidenceJSON.rulingOptions.titles.slice(
-                                  0,
-                                  255
-                                )
-                              }
-                              value={complexRuling}
-                            />
-                          ) : metaEvidence.metaEvidenceJSON.rulingOptions
-                              .type === 'datetime' ? (
-                            <DatePicker
-                              disabled={!votesData.canVote}
-                              disabledDate={disabledDate}
-                              onChange={setComplexRuling}
-                              showTime
-                              size="large"
-                              value={complexRuling}
-                            />
-                          ) : (
-                            <InputNumber
-                              disabled={!votesData.canVote}
-                              max={Number(
-                                realitioLibQuestionFormatter
-                                  .maxNumber({
-                                    decimals:
-                                      metaEvidence.metaEvidenceJSON
-                                        .rulingOptions.precision,
-                                    type:
-                                      metaEvidence.metaEvidenceJSON
-                                        .rulingOptions.type
-                                  })
-                                  .minus(1)
-                              )}
-                              min={Number(
-                                realitioLibQuestionFormatter.minNumber({
-                                  decimals:
-                                    metaEvidence.metaEvidenceJSON.rulingOptions
-                                      .precision,
-                                  type:
-                                    metaEvidence.metaEvidenceJSON.rulingOptions
-                                      .type
-                                })
-                              )}
-                              onChange={setComplexRuling}
-                              precision={
-                                metaEvidence.metaEvidenceJSON.rulingOptions
-                                  .precision
-                              }
-                              size="large"
-                              value={complexRuling}
-                            />
-                          )}
-                        </StyledButtonsDiv>
-                      )}
-                      <StyledButtonsDiv>
-                        {metaEvidence.metaEvidenceJSON.rulingOptions.type ===
-                        'single-select' ? (
-                          metaEvidence.metaEvidenceJSON.rulingOptions.titles &&
-                          metaEvidence.metaEvidenceJSON.rulingOptions.titles
-                            .slice(0, 2 ** 256 - 1)
-                            .map((t, i) => (
-                              <StyledButton
-                                disabled={!votesData.canVote}
-                                id={i + 1}
-                                key={t}
-                                onClick={onVoteClick}
-                                size="large"
-                                type="primary"
-                              >
-                                {t}
-                              </StyledButton>
-                            ))
-                        ) : (
-                          <StyledButton
-                            disabled={!votesData.canVote || !complexRuling}
-                            onClick={onVoteClick}
-                            size="large"
-                            type="primary"
-                          >
-                            Submit
-                          </StyledButton>
-                        )}
-                      </StyledButtonsDiv>
-                    </>
-                  )}
-              </StyledActionsDiv>
-              <StyledDiv
-                className="secondary-background theme-background"
-                style={{ display: 'inherit' }}
-              >
-                {Number(dispute.period) < '3' && (
-                  <Button
-                    disabled={!votesData.canVote}
-                    ghost={votesData.canVote}
-                    id={0}
-                    onClick={onVoteClick}
-                    size="large"
-                  >
-                    Refuse to Arbitrate
-                  </Button>
-                )}
-              </StyledDiv>
-            </>
-          ) : (
-            <StyledDiv className="secondary-linear-background theme-linear-background" />
-          )}
-        </Spin>
-      ])}
-      extra={
-        <StyledPoliciesButton
-          onClick={useCallback(
-            () => dispute && setActiveSubcourtID(dispute.subcourtID),
-            [dispute && dispute.subcourtID]
-          )}
-        >
-          <StyledDocument /> Policies
-        </StyledPoliciesButton>
-      }
-      loading={!metaEvidence}
-      title={
-        <>
-          {metaEvidence && metaEvidence.metaEvidenceJSON.title}
-          {subcourts && (
-            <StyledBreadcrumbs breadcrumbs={subcourts.map(s => s.name)} />
-          )}
-        </>
-      }
-    >
-      {metaEvidence && (
-        <>
-          <Row>
-            <Col span={24}>
-              <StyledInnerCard actions={metaEvidenceActions}>
-                <ReactMarkdown
-                  source={metaEvidence.metaEvidenceJSON.description}
-                />
-                {metaEvidence.metaEvidenceJSON.evidenceDisplayInterfaceURI && (
-                  <StyledIFrame
-                    frameBorder="0"
-                    src={`${metaEvidence.metaEvidenceJSON.evidenceDisplayInterfaceURI.replace(
-                      /^\/ipfs\//,
-                      'https://ipfs.kleros.io/ipfs/'
-                    )}?${encodeURIComponent(
-                      JSON.stringify({
-                        arbitrableContractAddress: dispute.arbitrated,
-                        arbitratorContractAddress:
-                          drizzle.contracts.KlerosLiquid.address,
-                        disputeID: ID
-                      })
-                    )}`}
-                    title="MetaEvidence Display"
-                    height={metaEvidence.metaEvidenceJSON.evidenceDisplayHeight || '215px'}
-                  />
-                )}
-                {metaEvidence.metaEvidenceJSON.arbitrableInterfaceURI && (
-                  <ArbitrableInterfaceDiv>
-                    <a
-                      href={
-                        metaEvidence.metaEvidenceJSON.arbitrableInterfaceURI
-                      }
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Icon
-                        type="double-right"
-                        style={{ marginRight: '5px' }}
-                      />
-                      Go to the Arbitrable Application
-                    </a>
-                  </ArbitrableInterfaceDiv>
-                )}
-                {ID === '302' ? (
-                  <ArbitrableInterfaceDiv>
-                    This realitio dispute has been created by Omen, we advise
-                    you to read the{' '}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={'https://omen.eth.link/rules.pdf'}
-                    >
-                      Omen Rules
-                    </a>{' '}
-                    and consult the evidence provided in the{' '}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={
-                        'https://omen.eth.link/#/0xffbc624070cb014420a6f7547fd05dfe635e2db2'
-                      }
-                    >
-                      Market Comments.
-                    </a>
-                  </ArbitrableInterfaceDiv>
-                ) : (
-                  ''
-                )}
-                {ID === '532' ? (
-                  <ArbitrableInterfaceDiv>
-                    This realitio dispute has been created by Omen, we advise
-                    you to read the{' '}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={'https://omen.eth.link/rules.pdf'}
-                    >
-                      Omen Rules
-                    </a>{' '}
-                    and consult the evidence provided in the{' '}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={
-                        'https://omen.eth.link/#/0x95b2271039b020aba31b933039e042b60b063800'
-                      }
-                    >
-                      Market Comments.
-                    </a>
-                  </ArbitrableInterfaceDiv>
-                ) : (
-                  ''
-                )}
-              </StyledInnerCard>
-            </Col>
-          </Row>
-          <CollapsableCard
-            title={
-              <>
-                <Folder /> {`Evidence (${evidence ? evidence.length : 0})`}
-              </>
-            }
-          >
-            <EvidenceTimeline
-              evidence={evidence}
-              metaEvidence={metaEvidence}
-              ruling={dispute.period === '4' ? votesData.currentRuling : null}
-            />
-          </CollapsableCard>
-          {dispute2 &&
-            metaEvidence &&
-            metaEvidence.metaEvidenceJSON.rulingOptions &&
-            metaEvidence.metaEvidenceJSON.rulingOptions.type ===
-              'single-select' && (
-              <CollapsableCard
-                title={
-                  <>
-                    <Scales /> Dispute History
-                  </>
-                }
-              >
-                <CaseRoundHistory
-                  ID={ID}
-                  dispute={{
-                    ...dispute2,
-                    ...dispute
-                  }}
-                  ruling={
-                    dispute.period === '4' ? votesData.currentRuling : null
-                  }
-                />
-              </CollapsableCard>
-            )}
-        </>
-      )}
-      {activeSubcourtID !== undefined && (
-        <CourtDrawer ID={activeSubcourtID} onClose={setActiveSubcourtID} />
-      )}
-    </StyledCard>
-  )
-}
-
-CaseDetailsCard.propTypes = {
-  ID: PropTypes.string.isRequired
-}
-
-export default CaseDetailsCard
+`;

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -154,11 +154,11 @@ export default function CaseDetailsCard({ ID }) {
 
   const { account } = drizzleState;
   const { web3 } = drizzle;
-  const useStoredCommitedVote = React.useMemo(() => createPersistedState(`@kleros/court/${account}/${ID}/vote`), [
+  const useStoredCommittedVote = React.useMemo(() => createPersistedState(`@kleros/court/${account}/${ID}/vote`), [
     ID,
     account,
   ]);
-  const [committedVote, setCommittedVote] = useStoredCommitedVote();
+  const [committedVote, setCommittedVote] = useStoredCommittedVote();
 
   const sendOrRevealVote = useCallback(
     async (choice) => {
@@ -378,8 +378,8 @@ export default function CaseDetailsCard({ ID }) {
                     <Alert
                       showIcon
                       type="warning"
-                      message="Could not find your commited vote"
-                      description="You probably commited to your vote from another device. You will need to manually select the voted option(s) and submit it."
+                      message="Could not find your committed vote"
+                      description="You probably committed to your vote from another device. You will need to manually select the voted option(s) and submit it."
                       css={`
                         text-align: left;
                         margin-top: 2rem;

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -310,49 +310,54 @@ export default function CaseDetailsCard({ ID }) {
               <StyledActionsDiv className="secondary-linear-background theme-linear-background">
                 {dispute.period !== "2" ? <GavelLarge /> : ""}
                 {votesData.drawnInCurrentRound ? (
-                  votesData.canVote ? (
-                    metaEvidence.metaEvidenceJSON.question ? (
-                      metaEvidence.metaEvidenceJSON.question
+                  <>
+                    <div
+                      css={`
+                        margin-bottom: 20px;
+                      `}
+                    >
+                      {metaEvidence.metaEvidenceJSON.question
+                        ? metaEvidence.metaEvidenceJSON.question
+                        : "What is your decision?"}
+                    </div>
+                    {votesData.voted ? (
+                      <>
+                        <div>
+                          You voted for: &ldquo;
+                          {votesData.voted === "0"
+                            ? "Refuse to Arbitrate"
+                            : (metaEvidence.metaEvidenceJSON.rulingOptions &&
+                                realitioLibQuestionFormatter.getAnswerString(
+                                  {
+                                    decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
+                                    outcomes: metaEvidence.metaEvidenceJSON.rulingOptions.titles,
+                                    type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
+                                  },
+                                  realitioLibQuestionFormatter.padToBytes32(
+                                    toBN(votesData.voted).sub(toBN("1")).toString(16)
+                                  )
+                                )) ||
+                              "Unknown Choice"}
+                          &rdquo;.
+                        </div>
+                        {Number(dispute.period) < 4 ? (
+                          <SecondaryActionText>Waiting for the vote result.</SecondaryActionText>
+                        ) : null}
+                      </>
+                    ) : dispute.period === "0" ? (
+                      "Waiting for evidence."
+                    ) : dispute.period === "1" ? (
+                      "Waiting to reveal your vote."
+                    ) : subcourts[subcourts.length - 1].hiddenVotes ? (
+                      votesData.committed ? (
+                        "You did not reveal your vote."
+                      ) : (
+                        "You did not commit a vote."
+                      )
                     ) : (
-                      "What is your decision?"
-                    )
-                  ) : votesData.voted ? (
-                    <>
-                      <div>
-                        You voted for: &ldquo;
-                        {votesData.voted === "0"
-                          ? "Refuse to Arbitrate"
-                          : (metaEvidence.metaEvidenceJSON.rulingOptions &&
-                              realitioLibQuestionFormatter.getAnswerString(
-                                {
-                                  decimals: metaEvidence.metaEvidenceJSON.rulingOptions.precision,
-                                  outcomes: metaEvidence.metaEvidenceJSON.rulingOptions.titles,
-                                  type: metaEvidence.metaEvidenceJSON.rulingOptions.type,
-                                },
-                                realitioLibQuestionFormatter.padToBytes32(
-                                  toBN(votesData.voted).sub(toBN("1")).toString(16)
-                                )
-                              )) ||
-                            "Unknown Choice"}
-                        &rdquo;.
-                      </div>
-                      {Number(dispute.period) < 4 ? (
-                        <SecondaryActionText>Waiting for the vote result.</SecondaryActionText>
-                      ) : null}
-                    </>
-                  ) : dispute.period === "0" ? (
-                    "Waiting for evidence."
-                  ) : dispute.period === "1" ? (
-                    "Waiting to reveal your vote."
-                  ) : subcourts[subcourts.length - 1].hiddenVotes ? (
-                    votesData.committed ? (
-                      "You did not reveal your vote."
-                    ) : (
-                      "You did not commit a vote."
-                    )
-                  ) : (
-                    "You did not cast a vote."
-                  )
+                      "You did not cast a vote."
+                    )}
+                  </>
                 ) : (
                   "You were not drawn in the current round."
                 )}
@@ -414,14 +419,14 @@ export default function CaseDetailsCard({ ID }) {
                     value={justification}
                   />
                 )}
-                {Number(dispute.period) < 3 && votesData.canVote && metaEvidence.metaEvidenceJSON.rulingOptions ? (
+                {Number(dispute.period) < 3 && !votesData.voted && metaEvidence.metaEvidenceJSON.rulingOptions ? (
                   votesData.committed && committedVote !== undefined ? (
                     <StyledButtonsDiv>
                       <StyledButton
                         onClick={onRevealClick}
                         size="large"
                         type="primary"
-                        disabled={dispute.period !== "2"}
+                        disabled={!votesData.canVote || dispute.period !== "2"}
                       >
                         Reveal Vote
                       </StyledButton>
@@ -512,7 +517,7 @@ export default function CaseDetailsCard({ ID }) {
                 ) : null}
               </StyledActionsDiv>
               <StyledDiv className="secondary-background theme-background" style={{ display: "inherit" }}>
-                {Number(dispute.period) < "3" && (
+                {Number(dispute.period) < "3" && !votesData.voted ? (
                   <Button
                     disabled={!votesData.canVote}
                     ghost={votesData.canVote}
@@ -522,7 +527,7 @@ export default function CaseDetailsCard({ ID }) {
                   >
                     Refuse to Arbitrate
                   </Button>
-                )}
+                ) : null}
               </StyledDiv>
             </>
           ) : (

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -308,7 +308,7 @@ export default function CaseDetailsCard({ ID }) {
           {!votesData.loading && subcourts && metaEvidence ? (
             <>
               <StyledActionsDiv className="secondary-linear-background theme-linear-background">
-                {dispute.period !== "2" ? <GavalLarge /> : ""}
+                {dispute.period !== "2" ? <GavelLarge /> : ""}
                 {votesData.drawnInCurrentRound ? (
                   votesData.canVote ? (
                     metaEvidence.metaEvidenceJSON.question ? (
@@ -821,7 +821,7 @@ const StyledPoliciesButton = styled(Button)`
   position: relative;
 `;
 
-const GavalLarge = styled(Gavel)`
+const GavelLarge = styled(Gavel)`
   height: 150px;
   opacity: 0.15;
   position: absolute;

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components/macro";
 import { Alert, Button, Card, Checkbox, Col, DatePicker, Icon, Input, InputNumber, Row, Spin } from "antd";
@@ -149,13 +149,13 @@ export default function CaseDetailsCard({ ID }) {
 
   const { account } = drizzleState;
   const { web3 } = drizzle;
-  const useStoredCommittedVote = React.useMemo(() => createPersistedState(`@kleros/court/${account}/${ID}/vote`), [
+  const useStoredCommittedVote = useMemo(() => createPersistedState(`@kleros/court/${account}/${ID}/vote`), [
     ID,
     account,
   ]);
   const [committedVote, setCommittedVote] = useStoredCommittedVote();
 
-  React.useEffect(() => {
+  useEffect(() => {
     let mounted = true;
 
     async function deriveCommitedVote() {

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -1,25 +1,25 @@
-import * as realitioLibQuestionFormatter from "@realitio/realitio-lib/formatters/question";
-import { Alert, Button, Card, Checkbox, Col, DatePicker, Icon, Input, InputNumber, Row, Spin } from "antd";
 import React, { useCallback, useMemo, useState } from "react";
-import Web3 from "web3";
+import PropTypes from "prop-types";
+import styled from "styled-components/macro";
+import { Alert, Button, Card, Checkbox, Col, DatePicker, Icon, Input, InputNumber, Row, Spin } from "antd";
 import { drizzleReactHooks } from "@drizzle/react-plugin";
+import * as realitioLibQuestionFormatter from "@realitio/realitio-lib/formatters/question";
+import ReactMarkdown from "react-markdown";
 import createPersistedState from "use-persisted-state";
+import Web3 from "web3";
+import { ReactComponent as Document } from "../assets/images/document.svg";
+import { ReactComponent as Folder } from "../assets/images/folder.svg";
+import { ReactComponent as Gavel } from "../assets/images/gavel.svg";
+import { ReactComponent as Scales } from "../assets/images/scales.svg";
 import { API } from "../bootstrap/api";
+import { useDataloader, VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
+import web3Salt from "../temp/web3-salt";
 import Attachment from "./attachment";
 import Breadcrumbs from "./breadcrumbs";
 import CaseRoundHistory from "./case-round-history";
 import CollapsableCard from "./collapsable-card";
 import CourtDrawer from "./court-drawer";
-import { ReactComponent as Document } from "../assets/images/document.svg";
-import { ReactComponent as Folder } from "../assets/images/folder.svg";
-import { ReactComponent as Gavel } from "../assets/images/gavel.svg";
-import { ReactComponent as Scales } from "../assets/images/scales.svg";
 import EvidenceTimeline from "./evidence-timeline";
-import PropTypes from "prop-types";
-import ReactMarkdown from "react-markdown";
-import styled from "styled-components/macro";
-import { useDataloader, VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
-import web3Salt from "../temp/web3-salt";
 
 const { useDrizzle, useDrizzleState } = drizzleReactHooks;
 

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -46,7 +46,7 @@ export const range = (lengthOrStart, end) => {
  * @param {number} length The number of bits to generate the permutation.
  * @return {(0|1)[][]} The binary permutation of `length` bits.
  */
-export const binaryPermutation = (length) => {
+export const binaryPermutations = (length) => {
   const permutations = [];
   for (let i = 0; i < Math.pow(2, length); i++) {
     permutations.push(i.toString(2).padStart(length, "0").split("").map(Number));

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -1,0 +1,55 @@
+/**
+ * Returns an array containing a range of numbers. O(n).
+ *
+ * It can be called with 1 or 2 parameters like:
+ *
+ *  `range(length)` - Will produce an array of size `length` with items from `0` to `length - 1`.
+ *  `range(start, end)` - Will produce an array of size `end - start` with items from `start` to `end - 1`.
+ *
+ * Examples:
+ *
+ * - `range(10)     // --> [0, 1, ..., 9]`
+ * - `range(0, 10)  // --> [0, 1, ..., 9] (same as range(10))`
+ * - `range(10, 20) // --> [10, 11, ..., 19]`
+ *
+ * @param {number} lengthOrStart The length of the array or its starting value (inclusive).
+ * @param {number|undefined} end [OPTIONAL] If ommited, `lengthOrStart` is treated like it's the length of the array. If provided it will determine its ending value (exclusive).
+ * @return {number[]} The range array.
+ */
+export const range = (lengthOrStart, end) => {
+  const length = end === undefined ? lengthOrStart : end - lengthOrStart;
+  const start = end === undefined ? 0 : lengthOrStart;
+
+  return Array(length)
+    .fill()
+    .map((_, i) => start + i);
+};
+
+/**
+ * Returns an array containing arrays for the binary permutation of `length` bits. O(2^n).
+ *
+ * Each item in the nested array is the value of the bit in the n-th position.
+ *
+ * Example:
+ *
+ * - `binaryPermutation(3)` will produce:
+ *
+ *    [ [ 0, 0, 0 ],
+ *      [ 0, 0, 1 ],
+ *      [ 0, 1, 0 ],
+ *      [ 0, 1, 1 ],
+ *      [ 1, 0, 0 ],
+ *      [ 1, 0, 1 ],
+ *      [ 1, 1, 0 ],
+ *      [ 1, 1, 1 ] ]
+ *
+ * @param {number} length The number of bits to generate the permutation.
+ * @return {(0|1)[][]} The binary permutation of `length` bits.
+ */
+export const binaryPermutation = (length) => {
+  const permutations = [];
+  for (let i = 0; i < Math.pow(2, length); i++) {
+    permutations.push(i.toString(2).padStart(length, "0").split("").map(Number));
+  }
+  return permutations;
+};


### PR DESCRIPTION
The Court UI currently does not store the committed vote anywhere when hidden votes are enabled.

The interface can become a bit confusing, because vote and reveal would show the same options and the jurors are required to select the same options they selected in the first place. If they choose wrong, the transaction will fail (MetaMask will show a warning at least).

Since hidden votes are enabled on xDAI General Court, I implemented some changes in the voting widget that will allow to store the committed vote locally and present it to the user. To reveal, instead of selecting all options over again, it simply submits the stored vote.

~Notice that this will only work if the jurors reveal their votes using the same device they used to commit to that specific case. In case the UI cannot find the committed vote stored locally, it will fallback to the current behavior, requiring the jurors to select the option(s) they committed to.~

We are able to derive the original vote for cases whose expected answer is of type `single-select` or `multiple-select` even if the jurors try to reveal it from a different device. 