### PR TITLE
Feat: added JSON RPC endpoint and chain ID injection to scripts and display interfaces

### DIFF
--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -1,117 +1,114 @@
-import { useEffect, useRef, useState } from 'react'
-import Dataloader from 'dataloader'
-import archon from './archon'
+import { useEffect, useRef, useState } from "react";
+import Dataloader from "dataloader";
+import archon from "./archon";
+import { getReadOnlyRpcUrl } from "./web3";
 
 const funcs = {
   getAppealDecision: (arbitratorAddress, disputeID, appeal, options) =>
     archon.arbitrator
       .getAppealDecision(arbitratorAddress, disputeID, appeal, {
-        ...options
+        ...options,
       })
       .catch(() => ({
-        appealedAt: null
+        appealedAt: null,
       })),
   getDisputeCreation: (arbitratorAddress, disputeID, options) =>
     archon.arbitrator.getDisputeCreation(arbitratorAddress, disputeID, {
-      ...options
+      ...options,
     }),
   getEvidence: (contractAddress, arbitratorAddress, disputeID, options) =>
     archon.arbitrable
       .getDispute(contractAddress, arbitratorAddress, disputeID, {
-        ...options
+        ...options,
       })
-      .then(d =>
-        archon.arbitrable.getEvidence(
-          contractAddress,
-          arbitratorAddress,
-          d.evidenceGroupID,
-          {
-            ...options
-          }
-        )
+      .then((d) =>
+        archon.arbitrable.getEvidence(contractAddress, arbitratorAddress, d.evidenceGroupID, {
+          ...options,
+        })
       )
-      .then(evidence =>
-        evidence.filter(
-          e => e.evidenceJSONValid && (!e.evidenceJSON.fileURI || e.fileValid)
-        )
-      ),
-  getMetaEvidence: (contractAddress, arbitratorAddress, disputeID, options) =>
-    archon.arbitrable
-      .getDispute(contractAddress, arbitratorAddress, disputeID, {
-        ...options
-      })
-      .then(d =>
-        archon.arbitrable.getMetaEvidence(
-          contractAddress,
-          disputeID === '560' ? '2' : d.metaEvidenceID,
-          {
-            scriptParameters: {
-              disputeID,
-              arbitrableContractAddress: contractAddress,
-              arbitratorContractAddress: arbitratorAddress
-            },
-            strictHashes: true,
-            ...options
-          }
-        )
-      )
-      .catch(e => {
-        console.log(e)
-        return {
-          metaEvidenceJSON: {
-            description:
-              'The data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.',
-            title: 'Invalid or tampered case data, refuse to arbitrate.'
-          }
+      .then((evidence) => evidence.filter((e) => e.evidenceJSONValid && (!e.evidenceJSON.fileURI || e.fileValid))),
+  async getMetaEvidence(chainId, contractAddress, arbitratorAddress, disputeID, options) {
+    try {
+      const jsonRpcUrl = getReadOnlyRpcUrl({ chainId });
+      const dispute = await archon.arbitrable.getDispute(contractAddress, arbitratorAddress, disputeID, { ...options });
+
+      const metaEvidence = await archon.arbitrable.getMetaEvidence(
+        contractAddress,
+        disputeID === "560" ? "2" : dispute.metaEvidenceID,
+        {
+          scriptParameters: {
+            disputeID,
+            arbitrableContractAddress: contractAddress,
+            arbitratorContractAddress: arbitratorAddress,
+            jsonRpcUrl,
+          },
+          strictHashes: true,
+          ...options,
         }
-      }),
+      );
+
+      return metaEvidence;
+    } catch (err) {
+      // handle error...
+      console.warn("Failed to get the evidence:", err);
+      return {
+        metaEvidenceJSON: {
+          description:
+            "The data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.",
+          title: "Invalid or tampered case data, refuse to arbitrate.",
+        },
+      };
+    }
+  },
   loadPolicy: (URI, options) => {
-    if (!options) options = {}
-    if (URI.startsWith('/ipfs/')) options.preValidated = true
+    if (!options) options = {};
+    if (URI.startsWith("/ipfs/")) options.preValidated = true;
 
     return archon.utils
-      .validateFileFromURI(
-        URI.replace(/^\/ipfs\//, 'https://ipfs.kleros.io/ipfs/'),
-        {
-          ...options
-        }
-      )
-      .then(res => res.file)
+      .validateFileFromURI(URI.replace(/^\/ipfs\//, "https://ipfs.kleros.io/ipfs/"), {
+        ...options,
+      })
+      .then((res) => res.file)
       .catch(() => ({
-        description: 'Please contact the governance team.',
-        name: 'Invalid Court Data',
+        description: "Please contact the governance team.",
+        name: "Invalid Court Data",
         summary:
-          'The data for this court is not formatted correctly or has been tampered since the time of its submission.'
-      }))
-  }
-}
+          "The data for this court is not formatted correctly or has been tampered since the time of its submission.",
+      }));
+  },
+};
 export const dataloaders = Object.keys(funcs).reduce((acc, f) => {
-  acc[f] = new Dataloader(
-    argsArr => Promise.all(argsArr.map(args => funcs[f](...args))),
-    { cacheKeyFn: JSON.stringify }
-  )
-  return acc
-}, {})
+  acc[f] = new Dataloader((argsArr) => Promise.all(argsArr.map((args) => funcs[f](...args))), {
+    cacheKeyFn: JSON.stringify,
+  });
+  return acc;
+}, {});
 
 export const useDataloader = Object.keys(dataloaders).reduce((acc, f) => {
-  acc[f] = () => {
-    const [state, setState] = useState({})
-    const loadedRef = useRef({})
-    let mounted = true
-    useEffect(() => () => (mounted = false))
+  acc[f] = function useData() {
+    const [state, setState] = useState({});
+    const loadedRef = useRef({});
+
+    let mounted = useRef(true);
+
+    useEffect(() => () => (mounted.current = false), []);
+
     return (...args) => {
-      const key = JSON.stringify(args)
+      const key = JSON.stringify(args);
       return loadedRef.current[key]
         ? state[key]
-        : dataloaders[f].load(args).then(res => {
-            if (mounted) {
-              loadedRef.current[key] = true
-              setState(state => ({ ...state, [key]: res }))
+        : dataloaders[f].load(args).then((res) => {
+            if (mounted.current) {
+              loadedRef.current[key] = true;
+              setState((state) => ({ ...state, [key]: res }));
             }
-          }) && undefined
-    }
-  }
-  return acc
-}, {})
+          }) && undefined;
+    };
+  };
 
-export const VIEW_ONLY_ADDRESS = '0x0000000000000000000000000000000000000000'
+  Object.defineProperty(acc[f], "name", { value: f });
+
+  return acc;
+}, {});
+
+export const VIEW_ONLY_ADDRESS = "0x0000000000000000000000000000000000000000";

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -41,6 +41,7 @@ const funcs = {
             arbitrableContractAddress: contractAddress,
             arbitratorContractAddress: arbitratorAddress,
             jsonRpcUrl,
+            chainID: chainId,
           },
           strictHashes: true,
           ...options,

--- a/src/bootstrap/web3.js
+++ b/src/bootstrap/web3.js
@@ -38,11 +38,15 @@ const chainIdToRpcEndpoint = {
   100: process.env.REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL,
 };
 
-export function getReadOnlyWeb3({ chainId }) {
+export function getReadOnlyRpcUrl({ chainId }) {
   const url = chainIdToRpcEndpoint[chainId];
   if (!url) {
     throw new Error(`Unsupported chain ID: ${chainId}`);
   }
 
-  return new Web3(url);
+  return url;
+}
+
+export function getReadOnlyWeb3({ chainId }) {
+  return new Web3(getReadOnlyRpcUrl({ chainId }));
 }

--- a/src/components/case-card.js
+++ b/src/components/case-card.js
@@ -9,6 +9,7 @@ import rewardImg from "../assets/images/reward.png";
 import { ReactComponent as Hexagon } from "../assets/images/hexagon.svg";
 import { ReactComponent as Scales } from "../assets/images/scales.svg";
 import { useDataloader } from "../bootstrap/dataloader";
+import useChainId from "../hooks/use-chain-id";
 import Hint from "./hint";
 import ETHAmount from "./eth-amount";
 
@@ -130,7 +131,9 @@ const StakeLocked = styled.div`
   line-height: 16px;
   text-align: right;
 `;
+
 const CaseCard = ({ ID, draws }) => {
+  const chainId = useChainId();
   const { drizzle, useCacheCall } = useDrizzle();
   const getMetaEvidence = useDataloader.getMetaEvidence();
   const dispute = useCacheCall("KlerosLiquid", "disputes", ID);
@@ -175,11 +178,11 @@ const CaseCard = ({ ID, draws }) => {
   let metaEvidence;
   if (dispute) {
     if (dispute.ruled) {
-      metaEvidence = getMetaEvidence(dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID, {
+      metaEvidence = getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID, {
         strictHashes: false,
       });
     } else {
-      metaEvidence = getMetaEvidence(dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
+      metaEvidence = getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
     }
   }
   return (

--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -5,6 +5,7 @@ import { Col, Radio, Row, Skeleton } from "antd";
 import { drizzleReactHooks } from "@drizzle/react-plugin";
 import { useAPI } from "../bootstrap/api";
 import { useDataloader, VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
+import useChainId from "../hooks/use-chain-id";
 import ScrollBar from "./scroll-bar";
 
 const { useDrizzle, useDrizzleState } = drizzleReactHooks;
@@ -19,15 +20,16 @@ export default function CaseRoundHistory({ ID, dispute, ruling }) {
   const [round, setRound] = useState(dispute.votesLengths.length - 1);
   const [rulingOption, setRulingOption] = useState(Number(ruling) || 1);
   const [justificationIndex, setJustificationIndex] = useState(0);
+  const chainId = useChainId();
 
   let metaEvidence;
   if (dispute)
     if (dispute.ruled) {
-      metaEvidence = getMetaEvidence(dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID, {
+      metaEvidence = getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID, {
         strictHashes: false,
       });
     } else {
-      metaEvidence = getMetaEvidence(dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
+      metaEvidence = getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
     }
 
   const justifications = dispute.votesLengths.map((_, i) => {


### PR DESCRIPTION
There is an issue with how we handle both Dynamic Scripts and Evidence Display Interfaces.
Those components usually only read things from the blockchain and IPFS, so they usually connect to the blockchain through a JSON RPC endpoint.

Currently those components are bundled and published to IPFS, which means that the JSON RPC endpoints must be calculated at bundling time and therefore are published as hardcoded values.

When it comes to Infura keys, we would never be able to deactivate/change the security restrictions of a key, risking an Evidence Display Interface or Dynamic Script stop working. Since we can only have up to 10 projects on Infura, this sounds unfeasible.
For key-less environments such as xDAI, we always risk endpoints being changed/deprecated.

This creates the following problems:

1. The Court being permanently unable to display the right Evidence Display Interface or fetching the appropriate data, which could lead to jurors refusing to rule on an otherwise valid case.
2. For older cases the problem is that we'd lose historical data.

Currently the Court interface injects the following parameters into both Evidence Display Interface and Dynamic Script:

- `arbitrableContractAddress`
- `arbitratorContractAddress`
- `disputeID`

I believe the Court should also inject a new parameter `jsonRpcUrl` into both components that would allow it to override to which endpoint they connect.
This injected parameter should take precedence over any hard coded value present into the Dynamic Script or the Evidence Display URI.

:rotating_light: Unfortunately this fix can't be retroactive, but could prevent catastrophic failures moving forward.
This would require patching all active Dynamic Scripts to support this new injected parameter.

Furthermore in a multi-chain/rollup world, we should add `chainID` to the list of injected parameters, since this would allow dynamic scripts and evidence display interfaces to check whether the JSON RPC endpoint is valid or not.