### PR TITLE
fix: remove manual window.ethereum activation

### DIFF
--- a/src/bootstrap/app.js
+++ b/src/bootstrap/app.js
@@ -110,25 +110,12 @@ export default function App() {
 function DrizzleChainIdProvider({ children }) {
   const { drizzle } = useDrizzle();
 
-  return <ChainIdProvider web3={drizzle.web3}>{children}</ChainIdProvider>;
+  return drizzle.web3 ? <ChainIdProvider web3={drizzle.web3}>{children}</ChainIdProvider> : <C404 Web3 />;
 }
 
 DrizzleChainIdProvider.propTypes = {
   children: t.node,
 };
-
-// function DrizzleForRequiredChainId() {
-//   const setDrizzle = useDrizzleSetter();
-//   const { requiredChainId } = useQueryParams();
-
-//   React.useEffect(() => {
-//     if (requiredChainId) {
-//       setDrizzle({ chainId: requiredChainId });
-//     }
-//   }, [setDrizzle, requiredChainId]);
-
-//   return null;
-// }
 
 const StyledSpin = styled(Spin)`
   left: 50%;

--- a/src/bootstrap/web3.js
+++ b/src/bootstrap/web3.js
@@ -2,23 +2,6 @@ import Web3 from "web3";
 
 let web3;
 
-window.document.addEventListener("DOMContentLoaded", async () => {
-  // Modern dapp browsers...
-  if (window.ethereum) {
-    window.web3 = new Web3(window.ethereum);
-    try {
-      // Request account access if needed
-      await window.ethereum.send("eth_requestAccounts");
-      // Acccounts now exposed
-    } catch (_) {
-      // User denied account access...
-    }
-  } else if (window.web3) {
-    // Legacy dapp browsers...
-    window.web3 = new Web3(web3.currentProvider);
-  }
-});
-
 if (typeof window !== "undefined" && typeof window.web3 !== "undefined") {
   web3 = new Web3(window.web3.currentProvider);
 } else if (process.env.REACT_APP_WEB3_FALLBACK_HTTPS_URL || process.env.REACT_APP_WEB3_FALLBACK_URL) {


### PR DESCRIPTION
This was causing `drizzle` to fail unlocking MetaMask when the app was accessed for the first time and then the page would break.

To reproduce the current behavior, simply deactivate and activate the MetaMask extension and then navigate to the Court.