### PR TITLE
Fix: unable to claim PNK rewards

### DIFF
--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { Modal, Button, Spin } from "antd";
 import { drizzleReactHooks } from "@drizzle/react-plugin";
 import MerkleRedeem from "@kleros/pnk-merkle-drop-contracts/deployments/mainnet/MerkleRedeem.json";
-import Web3 from "../bootstrap/web3";
 import { VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
 import { ReactComponent as Kleros } from "../assets/images/kleros.svg";
 import { ReactComponent as RightArrow } from "../assets/images/right-arrow.svg";
@@ -215,7 +214,7 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
       return;
     }
 
-    const contract = new Web3.eth.Contract(MerkleRedeem.abi, airdropParams.contractAddress);
+    const contract = new drizzle.web3.eth.Contract(MerkleRedeem.abi, airdropParams.contractAddress);
     const args = claimObjects(claims).filter((_claim) => Boolean(claimStatus[_claim.week]) === false);
 
     setCurrentClaimValue(


### PR DESCRIPTION
The contract that users will interact with is being wrongly instantiated from the `Web3` constructor and not the actual `web3` object. This object is provider-less, so calling `send()` does not do anything.