### PR TITLE
Fix Incomplete IFrame Display

### DIFF
--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -666,6 +666,7 @@ export default function CaseDetailsCard({ ID }) {
                   <ReactMarkdown source={metaEvidence.metaEvidenceJSON.description} />
                   {metaEvidence.metaEvidenceJSON.evidenceDisplayInterfaceURI && (
                     <iframe
+                      title="dispute details"
                       style={{ width: "1px", minWidth: "100%", height: "360px", border: "none" }}
                       src={evidenceDisplayInterfaceURL}
                     />

--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import IframeResizer from "iframe-resizer-react";
 import PropTypes from "prop-types";
 import styled from "styled-components/macro";
 import { Alert, Button, Card, Checkbox, Col, DatePicker, Icon, Input, InputNumber, Row, Spin } from "antd";
@@ -666,11 +665,9 @@ export default function CaseDetailsCard({ ID }) {
                 <StyledInnerCard actions={metaEvidenceActions}>
                   <ReactMarkdown source={metaEvidence.metaEvidenceJSON.description} />
                   {metaEvidence.metaEvidenceJSON.evidenceDisplayInterfaceURI && (
-                    <IframeResizer
-                      frameBorder="0"
-                      log
+                    <iframe
+                      style={{ width: "1px", minWidth: "100%", height: "360px", border: "none" }}
                       src={evidenceDisplayInterfaceURL}
-                      style={{ width: "1px", minWidth: "100%" }}
                     />
                   )}
                   {metaEvidence.metaEvidenceJSON.arbitrableInterfaceURI && (


### PR DESCRIPTION
In dispute 1170, we noticed iframe is not displayed completely. Removing `iframe-resizer` seems to be fixing this issue, however, scrollbars also returned. Still better than missing info.