### PR TITLE
Fix a Bug Where Claim Modal Shows There is an Unclaimed Amount When There is Not

### DIFF
--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -81,7 +81,7 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
   const [txHash, setTxHash] = useState(null);
   const [claimStatus, setClaimStatus] = useState(0);
   const [modalState, setModalState] = useState(0);
-  const [currentClaimValue, setCurrentClaimValue] = useState(12);
+  const [currentClaimValue, setCurrentClaimValue] = useState(0);
 
   const claimObjects = (claims) => {
     if (claims.length > 0)
@@ -164,7 +164,7 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
     );
 
     const contract = new drizzle.web3.eth.Contract(MerkleRedeem.abi, airdropParams.contractAddress);
-    const claimStatus = contract.methods.claimStatus(account, 0, 12).call();
+    const claimStatus = contract.methods.claimStatus(account, 0, chainIdToParams[chainId].snapshots.length).call();
 
     claimStatus.then((r) => setClaimStatus(r));
   }, [account, chainId, drizzle.web3.utils, drizzle.web3.eth.Contract, modalState, apyCallback, displayButton]);


### PR DESCRIPTION
`const claimStatus = contract.methods.claimStatus(account, 0, 12).call();`

The above statement was causing this bug. Initially, the juror incentive program was intended for 12 months (12 periods). So the statement is checking for 12 periods only. With March rewards, the 13th element entered the array (for Mainnet) thus the algorithm is failing to detect claimed status of March rewards and tries to claim them again and again.

Fix was simply dynamically calculating the snapshot length.

This is a high priority since it will annoy people. Please review and merge asap.