### PR TITLE
fix: show justifications for the ongoing round

### DIFF
--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -133,9 +133,7 @@ export default function CaseRoundHistory({ ID, dispute, ruling }) {
               <JustificationsBox>
                 <Skeleton active loading={justifications[round].loading}>
                   <h2>Justification</h2>
-                  {!justifications[round].loading &&
-                  justifications[round].byChoice[rulingOption].length &&
-                  !(!ruling && round === justifications.length - 1 && dispute.period < 3) ? (
+                  {!justifications[round].loading && justifications[round].byChoice[rulingOption].length ? (
                     <JustificationText>
                       {justifications[round].byChoice[rulingOption][justificationIndex]}
                     </JustificationText>


### PR DESCRIPTION
there seemed to be a deliberate choice
to hide the justifications for a vote
in the current ongoing round. im
not sure why.
it lies to the users (it will claim that there
are no justifications, which isn't true) and it's not obvious
why the current justifications should be hidden,
more so if the data is publicly available.
i guess rationale was to not sway jurors.

technical users can get that info from the endpoint
anyway. or they can read the network log.