### PR TITLE
chore: show reveal phase explicitly

### DIFF
--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -435,9 +435,9 @@ export default function CaseDetailsCard({ ID }) {
                         "Waiting to reveal your vote."
                       ) : subcourts[subcourts.length - 1].hiddenVotes ? (
                         votesData.committed ? (
-                          "You did not reveal your vote."
+                          "You did not reveal your vote yet."
                         ) : (
-                          "You did not commit a vote."
+                          "You did not commit a vote in the previous period. You cannot vote anymore."
                         )
                       ) : (
                         "You did not cast a vote."


### PR DESCRIPTION
Since we had two users wondering if they had bugs preventing them to vote, due to unfamiliarity with commit-reveal, it made sense to make the Reveal name explicit for the phases and show some extra info instead of just "You did not commit a vote".
Please give feedback on the messaging and feel free to contribute other explanations to clarify UX.