### PR TITLE
fix: clearer language for commit period

### DIFF
--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -432,7 +432,13 @@ export default function CaseDetailsCard({ ID }) {
                       ) : dispute.period === "0" ? (
                         "Waiting for evidence."
                       ) : dispute.period === "1" ? (
-                        "Waiting to reveal your vote."
+                        !votesData.committed ? (
+                          "You did not commit your vote yet."
+                        ) : (
+                          <small>
+                            You committed your vote. You will be able to reveal your vote when the period ends.
+                          </small>
+                        )
                       ) : subcourts[subcourts.length - 1].hiddenVotes ? (
                         votesData.committed ? (
                           "You did not reveal your vote yet."


### PR DESCRIPTION
One user was confused about "not being able to reveal" despite being in the commit period. The previous message, "Waiting to reveal your vote", could imply that the reveal has to be done in the current period, even though the period at the top left of the screen says "Commit Period", some redundancy is probably needed for UX.
I wrote distinct messages for having made your commit and pending commit, that clarifies that the revealing has to be done in the next period