### PR TITLE
fix: coherence rewards more clear now

### DIFF
--- a/src/components/case-card.js
+++ b/src/components/case-card.js
@@ -238,7 +238,7 @@ const CaseCard = ({ ID, draws }) => {
             <RewardCol md={16} xs={16}>
               <div>Coherence Reward</div>
               <h3>
-                <ETHAmount amount={disputeData && disputeData.coherenceReward} decimals={2} tokenSymbol={true} /> +
+                <ETHAmount amount={disputeData && disputeData.coherenceReward} decimals={3} tokenSymbol={true} />
               </h3>
             </RewardCol>
           </Row>

--- a/src/components/court-card.js
+++ b/src/components/court-card.js
@@ -180,7 +180,7 @@ const CourtCard = ({ ID, onClick, onStakeClick: _onStakeClick }) => {
             <RewardCol md={16} xs={16}>
               <div>Coherence Reward</div>
               <h3>
-                <ETHAmount amount={subcourt && subcourt.feeForJuror} decimals={2} tokenSymbol={true} /> +
+                <ETHAmount amount={subcourt && subcourt.feeForJuror} decimals={3} tokenSymbol={true} />
               </h3>
             </RewardCol>
           </Row>

--- a/src/components/court-cascader-modal.js
+++ b/src/components/court-cascader-modal.js
@@ -182,7 +182,7 @@ const CourtCascaderModal = ({ onClick }) => {
                       <div>
                         For each coherent vote you will receive{" "}
                         <strong>
-                          <ETHAmount amount={feeForJuror || null} decimals={2} tokenSymbol={true} /> +
+                          <ETHAmount amount={feeForJuror || null} decimals={3} tokenSymbol={true} />
                         </strong>
                         .
                       </div>

--- a/src/components/reward-card.js
+++ b/src/components/reward-card.js
@@ -211,7 +211,7 @@ const RewardCard = () => {
               <ETHOffset>
                 <StyledTopDiv>Total</StyledTopDiv>
                 <StyledCenterDiv>
-                  <ETHAmount amount={ethRewards} decimals={2} tokenSymbol={true} />
+                  <ETHAmount amount={ethRewards} decimals={3} tokenSymbol={true} />
                 </StyledCenterDiv>
               </ETHOffset>
             </AmountCol>


### PR DESCRIPTION
Closes #308 

added 1 more decimal
removed the '+' since it can be really confusing for the users, i think it's best if we just omit this, users should just have in mind the base reward they will ALWAYS get if they are coherent, and not take into accounts 'extras' getting their hopes up.