### PR TITLE
fix: old kleros tokens reincluded

### DIFF
--- a/src/components/case-details-card.js
+++ b/src/components/case-details-card.js
@@ -346,7 +346,14 @@ export default function CaseDetailsCard({ ID }) {
   const evidenceDisplayInterfaceURL = useMemo(() => {
     const normalizeIPFSUri = (uri) => uri.replace(/^\/ipfs\//, "https://ipfs.kleros.io/ipfs/");
     if (metaEvidence?.metaEvidenceJSON?.evidenceDisplayInterfaceURI) {
-      const { evidenceDisplayInterfaceURI, _v = "0" } = metaEvidence.metaEvidenceJSON;
+      // hack to allow displaying old t2cr disputes, since old endpoint was lost
+      const evidenceDisplayInterfaceURI =
+        dispute?.arbitrated === "0xEbcf3bcA271B26ae4B162Ba560e243055Af0E679"
+          ? "/ipfs/QmYs17mAJTaQwYeXNTb6n4idoQXmRcAjREeUdjJShNSeKh/index.html"
+          : metaEvidence.metaEvidenceJSON.evidenceDisplayInterfaceURI;
+
+      const { _v = "0" } = metaEvidence.metaEvidenceJSON;
+
       const arbitratorChainID = metaEvidence.metaEvidenceJSON?.arbitratorChainID ?? chainId;
       const arbitrableChainID = metaEvidence.metaEvidenceJSON?.arbitrableChainID ?? arbitratorChainID;
 

--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -24,6 +24,7 @@ const arbitrableWhitelist = {
     "0xd8bf5114796ed28aa52cff61e1b9ef4ec1f69a54",
     "0xe0e1bc8c6cd1b81993e2fcfb80832d814886ea38",
     "0xe5bcea6f87aaee4a81f64dfdb4d30d400e0e5cf4",
+    "0xebcf3bca271b26ae4b162ba560e243055af0e679",
     "0xf339047c85d0dd2645f2bd802a1e8a5e7af61053",
     "0xf65c7560d6ce320cc3a16a07f1f65aab66396b9e",
     "0xf72cfd1b34a91a64f9a98537fe63fbab7530adca",


### PR DESCRIPTION
readded main tokens arbitrable to whitelist
hack to check if arbitrable is tokens address, and swaps the uri in that case for the ipfs one

verified all kleros tokens badges arbitrables are in ipfs, so they don't need handling

the ipfs uri I put into the code can be found in the replacements approved by this snapshot proposal (which wasn't executed)
https://snapshot.org/#/kleros.eth/proposal/QmSaPoLb3oKCXkmRUEQgR7ZCN1vX8dMwCUonyErBFygTtc

note both submission and removal metaevidence share this evidence display

<img width="1110" alt="image" src="https://github.com/kleros/court/assets/40367733/facd39d6-d078-4960-a9ea-7aad4377fa27">
