### PR TITLE
Fix(web)/convert pnk crash

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,20 +55,6 @@
           "debug"
         ]
       }
-    ],
-    "no-restricted-imports": [
-      "error",
-      {
-        "paths": [
-          {
-            "name": "styled-components",
-            "message": "Please import from styled-components/macro."
-          }
-        ],
-        "patterns": [
-          "!styled-components/macro"
-        ]
-      }
     ]
   }
 }

--- a/src/containers/convert-pnk/convert-pnk-card.js
+++ b/src/containers/convert-pnk/convert-pnk-card.js
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components/macro";
+import styled from "styled-components";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { Card, Divider } from "antd";
 import { ButtonLink } from "../../adapters/antd";

--- a/src/containers/convert-pnk/wihdraw-stpnk-card.js
+++ b/src/containers/convert-pnk/wihdraw-stpnk-card.js
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components/macro";
+import styled from "styled-components";
 import Web3 from "web3";
 import { useSideChainApi } from "../../api/side-chain";
 import { Card, Button, Form, InputNumber } from "antd";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- This PR removes the restriction on importing from `styled-components/macro` and allows importing from `styled-components`.
- It changes the input field in `WithdrawStPnkForm` from `InputNumber` to `Input`.
- It updates the `handleUseMaxClick` function to set the value of the `amount` field to the maximum available value in the correct format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->