### PR TITLE
fix(web): bug disputes appearing in progress when they are finished

### DIFF
--- a/src/containers/cases.js
+++ b/src/containers/cases.js
@@ -41,6 +41,14 @@ export default function Cases() {
               return acc;
             }
 
+            if (dispute.period === "4") {
+              acc.executed.push({
+                ID: d.disputeID,
+                draws: numberOfVotes,
+              });
+              return acc;
+            }
+
             if (Number(d.appeal) !== dispute2.votesLengths.length - 1) {
               acc.active.push({
                 ID: d.disputeID,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Added a condition to push executed disputes into the `executed` array if the `dispute.period` is equal to "4".
- Added an object to the `executed` array with properties `ID` and `draws` which are set to `d.disputeID` and `numberOfVotes` respectively.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->