### PR TITLE
Fix for the Sepolia subgraph URL

### DIFF
--- a/src/bootstrap/subgraph.js
+++ b/src/bootstrap/subgraph.js
@@ -2,5 +2,5 @@ export const displaySubgraph = {
   1: "https://api.thegraph.com/subgraphs/name/kleros/kleros-display-mainnet",
   5: "https://api.thegraph.com/subgraphs/name/andreimvp/kleros-display-goerli",
   100: "https://api.thegraph.com/subgraphs/name/kleros/kleros-display-gnosis",
-  11155111: "https://api.studio.thegraph.com/query/50849/kleros-sepolia-gf/version/latest",
+  11155111: "https://api.thegraph.com/subgraphs/name/kleros/kleros-display-sepolia",
 };


### PR DESCRIPTION
Because the previous subgraph has been archived.

https://thegraph.com/hosted-service/subgraph/kleros/kleros-display-sepolia

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the subgraph URLs in the `subgraph.js` file for Kleros Display. 

### Detailed summary
- Updated subgraph URL for Goerli network
- Updated subgraph URL for Gnosis
- Updated subgraph URL for Sepolia

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->