### PR TITLE
chore: update-subgraph-endpoints

### DIFF
--- a/src/bootstrap/subgraph.js
+++ b/src/bootstrap/subgraph.js
@@ -1,6 +1,6 @@
 export const displaySubgraph = {
-  1: "https://api.thegraph.com/subgraphs/name/kleros/kleros-display-mainnet",
+  1: "https://api.studio.thegraph.com/query/61738/kleros-display-mainnet/version/latest",
   5: "https://api.thegraph.com/subgraphs/name/andreimvp/kleros-display-goerli",
-  100: "https://api.thegraph.com/subgraphs/name/kleros/kleros-display-gnosis",
-  11155111: "https://api.thegraph.com/subgraphs/name/kleros/kleros-display-sepolia",
+  100: "https://api.studio.thegraph.com/query/61738/kleros-display-gnosis/version/latest",
+  11155111: "https://api.studio.thegraph.com/query/61738/kleros-display-sepolia/version/latest",
 };

--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -54,7 +54,7 @@ const chainIdToParams = {
       "https://cdn.kleros.link/ipfs/QmbJ3tiiH7pRB6iLfSoJVtEG2dx7pY7YHCqc13y3FeekZQ/snapshot-2024-04.json",
     ],
     blockExplorerBaseUrl: "https://etherscan.io",
-    klerosboard: "https://api.thegraph.com/subgraphs/name/salgozino/klerosboard",
+    klerosboard: "https://api.studio.thegraph.com/query/66145/klerosboard-mainnet/version/latest",
   },
   100: {
     contractAddress: "0xf1A9589880DbF393F32A5b2d5a0054Fa10385074",
@@ -95,7 +95,7 @@ const chainIdToParams = {
       "https://cdn.kleros.link/ipfs/QmUYBkvBEDXLvLtnKBvPCj6fJgTJ9nDQYseU4f1Wo33AY2/xdai-snapshot-2024-04.json",
     ],
     blockExplorerBaseUrl: "https://blockscout.com/poa/xdai/",
-    klerosboard: "https://api.thegraph.com/subgraphs/name/salgozino/klerosboard-xdai",
+    klerosboard: "https://api.studio.thegraph.com/query/66145/klerosboard-gnosis/version/latest",
   },
 };
 


### PR DESCRIPTION
closes #407

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates subgraph URLs in `subgraph.js` and `claim-modal.js` to use The Graph Studio endpoints instead of The Graph legacy endpoints.

### Detailed summary
- Updated subgraph URLs in `subgraph.js` to use The Graph Studio endpoints
- Updated `klerosboard` URL in `claim-modal.js` to use The Graph Studio endpoint

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->