### PR TITLE
chore: add seer to arbitrable whitelist

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -29,6 +29,7 @@ const arbitrableWhitelist = {
     "0xf65c7560d6ce320cc3a16a07f1f65aab66396b9e",
     "0xf72cfd1b34a91a64f9a98537fe63fbab7530adca",
     "0x8453bA2C9eA5Bae36fDe6cBd61c12c05b6552425",
+    "0xFe0eb5fC686f929Eb26D541D75Bb59F816c0Aa68",
   ].map((address) => address.toLowerCase()),
   100: [
     "0x0b928165a67df8254412483ae8c3b8cc7f2b4d36",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new address to the list of allowed addresses in the `src/temp/arbitrable-whitelist.js` file, ensuring that it is included in the mapping of addresses to lowercase format.

### Detailed summary
- Added the address `0xFe0eb5fC686f929Eb26D541D75Bb59F816c0Aa68` to the existing array of addresses.
- Ensured the new address is processed to lowercase in the mapping function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->