### PR TITLE
Fix: add refuse to arbitrate when the dispute is not loading

### DIFF
--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -761,25 +761,25 @@ export default function CaseDetailsCard({ ID }) {
               .
             </div>
           )}
-          {Number(dispute.period) < "3" && !votesData.voted && (
-            <>
-              <div>
-                If the dispute is failing to load and appears to be broken it is advised to refuse to arbitrate. Please
-                cast your vote using button below.
-              </div>
-              <Button
-                style={{ color: "#4d00b4", marginTop: "16px", float: "right" }}
-                disabled={!votesData.canVote}
-                ghost={!votesData.canVote}
-                id={0}
-                onClick={onVoteClick}
-                size="large"
-              >
-                {"Refuse to Arbitrate"}
-              </Button>
-            </>
-          )}
         </div>
+      )}
+      {dispute && Number(dispute.period) < "3" && !votesData.voted && (
+        <>
+          <div style={{ marginTop: "32px" }}>
+            If the dispute is failing to load and appears to be broken it is advised to refuse to arbitrate. Please cast
+            your vote using button below.
+          </div>
+          <Button
+            style={{ color: "#4d00b4", marginTop: "16px", float: "right" }}
+            disabled={!votesData.canVote}
+            ghost={!votesData.canVote}
+            id={0}
+            onClick={onVoteClick}
+            size="large"
+          >
+            {"Refuse to Arbitrate"}
+          </Button>
+        </>
       )}
     </>
   );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refines the rendering logic for displaying a message and button related to voting in a dispute. It adds a check for the existence of `dispute` before rendering, and adjusts the styling of the message container.

### Detailed summary
- Added a check for `dispute` to ensure it exists before rendering the voting message and button.
- Increased the top margin of the message `div` to `32px`.
- The rest of the button and message content remains unchanged.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->