### PR TITLE
Zk sepolia proxy to whitelist

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -62,6 +62,7 @@ const arbitrableWhitelist = {
     "0xE620947519E8102aa625BBB4669fE317c9FffeD7",
     "0x1ec9729366e4C3eb8b8Ea776935508188051C0F4",
     "0xb994886066B17cfa0fE088C5933498B17FE66A50",
+    "0x54C68fa979883d317C10F3cfDdc33522889d5612",
   ].map((address) => address.toLowerCase()),
 };
 

--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -64,6 +64,7 @@ const arbitrableWhitelist = {
     "0xb994886066B17cfa0fE088C5933498B17FE66A50",
     "0x54C68fa979883d317C10F3cfDdc33522889d5612",
   ].map((address) => address.toLowerCase()),
+  300: ["0x54C68fa979883d317C10F3cfDdc33522889d5612"].map((address) => address.toLowerCase()),
 };
 
 export default arbitrableWhitelist;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new address to the `arbitrableWhitelist` in the `src/temp/arbitrable-whitelist.js` file, ensuring it is stored in lowercase format for consistency.

### Detailed summary
- Added the address `0x54C68fa979883d317C10F3cfDdc33522889d5612` to the existing array of addresses.
- Introduced a new mapping for the added address to ensure it is converted to lowercase.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->