### PR TITLE
chore: add omen proxy to whitelist

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -31,6 +31,7 @@ const arbitrableWhitelist = {
     "0x8453bA2C9eA5Bae36fDe6cBd61c12c05b6552425",
     "0xFe0eb5fC686f929Eb26D541D75Bb59F816c0Aa68",
     "0x2018038203aEE8e7a29dABd73771b0355D4F85ad",
+    "0xeF2Ae6961Ec7F2105bc2693Bc32fA7b7386B2f59",
   ].map((address) => address.toLowerCase()),
   100: [
     "0x0b928165a67df8254412483ae8c3b8cc7f2b4d36",
@@ -56,6 +57,7 @@ const arbitrableWhitelist = {
     "0xf7de5537ecd69a94695fcf4bcdbdee6329b63322",
     "0xFe0eb5fC686f929Eb26D541D75Bb59F816c0Aa68",
     "0x8453bA2C9eA5Bae36fDe6cBd61c12c05b6552425",
+    "0xeF2Ae6961Ec7F2105bc2693Bc32fA7b7386B2f59",
   ].map((address) => address.toLowerCase()),
   11155111: [
     "0x73E4F71e5ecE8d1319807DC7cd2EAA9Fda8F5182",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new Ethereum address to the `arbitrableWhitelist` in the `src/temp/arbitrable-whitelist.js` file, ensuring it is included in the list of approved addresses.

### Detailed summary
- Added the address `0xeF2Ae6961Ec7F2105bc2693Bc32fA7b7386B2f59` to the whitelist. 
- The address is included in two places within the file, ensuring consistent handling of the whitelist.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->