### PR TITLE
fix(web): show chain switch modal if dispute is absent

### DIFF
--- a/src/containers/case.js
+++ b/src/containers/case.js
@@ -81,7 +81,7 @@ export default function Case() {
     return disputeData.deadline && (new Date().getTime() - disputeData.deadline.getTime() > 30 * 365 * 24 * 60 * 60 * 1000);
   }, [disputeData.deadline]);
 
-  async function handleChainSwitch() {
+  async function handleChainSwitchToMainnet() {
     try {
       await window.ethereum.request({
         method: 'wallet_switchEthereumChain',
@@ -100,12 +100,12 @@ export default function Case() {
           visible={true}
           closable={false}
           footer={[
-            <Button key="switch" type="primary" onClick={handleChainSwitch}>
+            <Button key="switch" type="primary" onClick={handleChainSwitchToMainnet}>
               Switch to Mainnet
             </Button>,
           ]}
         >
-          <p>The dispute with ID {ID} does not exist on the {chainIdToNetworkName[chainId]}. Please switch to Mainnet.</p>
+          <p>The dispute with ID {ID} does not exist on {chainIdToNetworkName[chainId]}. Please switch to Mainnet.</p>
         </Modal>
       );
     }


### PR DESCRIPTION
closes #433

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new modal to handle cases where a dispute is too old and the user is not on the Mainnet. It enhances the `Case` component by adding logic for chain switching and rendering content conditionally based on dispute status.

### Detailed summary
- Added `useMemo` to check if a dispute is too old.
- Created `handleChainSwitchToMainnet` function to switch to the Mainnet.
- Introduced `renderContent` function to conditionally render a modal for old disputes.
- Replaced the original content rendering with a call to `renderContent()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->