### PR TITLE
Chore: update graph urls to production

### DIFF
--- a/.env
+++ b/.env
@@ -52,3 +52,6 @@ REACT_APP_WEB3_FALLBACK_SEPOLIA_HTTPS_URL='https://eth-sepolia.g.alchemy.com/v2/
 
 REACT_APP_WEB3_FALLBACK_POLYGON_HTTPS_URL='https://polygon-mainnet.g.alchemy.com/v2/Y2IRJuoY0G-LAkHTqyXdVetLFm4R2NZT'
 REACT_APP_WEB3_FALLBACK_MUMBAI_HTTPS_URL='https://polygon-mumbai.g.alchemy.com/v2/demo'
+
+REACT_APP_SUBGRAPH_MAINNET_DISPLAY='https://api.studio.thegraph.com/query/61738/kleros-display-mainnet/version/latest'
+REACT_APP_SUBGRAPH_GNOSIS_DISPLAY='https://api.studio.thegraph.com/query/61738/kleros-display-gnosis/version/latest'

--- a/.env
+++ b/.env
@@ -53,5 +53,5 @@ REACT_APP_WEB3_FALLBACK_SEPOLIA_HTTPS_URL='https://eth-sepolia.g.alchemy.com/v2/
 REACT_APP_WEB3_FALLBACK_POLYGON_HTTPS_URL='https://polygon-mainnet.g.alchemy.com/v2/Y2IRJuoY0G-LAkHTqyXdVetLFm4R2NZT'
 REACT_APP_WEB3_FALLBACK_MUMBAI_HTTPS_URL='https://polygon-mumbai.g.alchemy.com/v2/demo'
 
-REACT_APP_SUBGRAPH_MAINNET_DISPLAY='https://api.studio.thegraph.com/query/61738/kleros-display-mainnet/version/latest'
-REACT_APP_SUBGRAPH_GNOSIS_DISPLAY='https://api.studio.thegraph.com/query/61738/kleros-display-gnosis/version/latest'
+# REACT_APP_SUBGRAPH_MAINNET_DISPLAY='https://api.studio.thegraph.com/query/61738/kleros-display-mainnet/version/latest'
+# REACT_APP_SUBGRAPH_GNOSIS_DISPLAY='https://api.studio.thegraph.com/query/61738/kleros-display-gnosis/version/latest'

--- a/src/bootstrap/subgraph.js
+++ b/src/bootstrap/subgraph.js
@@ -1,7 +1,7 @@
 export const displaySubgraph = {
-  1: "https://api.studio.thegraph.com/query/61738/kleros-display-mainnet/version/latest",
+  1: process.env.REACT_APP_SUBGRAPH_MAINNET_DISPLAY,
   5: "https://api.thegraph.com/subgraphs/name/andreimvp/kleros-display-goerli",
-  100: "https://api.studio.thegraph.com/query/61738/kleros-display-gnosis/version/latest",
+  100: process.env.REACT_APP_SUBGRAPH_GNOSIS_DISPLAY,
   10200: "https://api.studio.thegraph.com/query/61738/kleros-display-chiado/version/latest",
   11155111: "https://api.studio.thegraph.com/query/61738/kleros-display-sepolia/version/latest",
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the configuration for subgraph URLs in a React application, moving hardcoded URLs to environment variables for better flexibility and security.

### Detailed summary
- Added new environment variables in `.env` for `REACT_APP_SUBGRAPH_MAINNET_DISPLAY` and `REACT_APP_SUBGRAPH_GNOSIS_DISPLAY`.
- Updated `src/bootstrap/subgraph.js` to use the new environment variables instead of hardcoded URLs for mainnet and Gnosis subgraphs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->