### PR TITLE
Fix: delay refuse to arbitrate

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,6 @@
   "volta": {
     "node": "16.20.2",
     "yarn": "1.22.10"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -241,6 +241,14 @@ export default function CaseDetailsCard({ ID }) {
   const metaEvidence = dispute && getMetaEvidence(chainId, dispute.arbitrated, KlerosLiquid.address, ID);
   const evidence = useEvidence(chainId, ID);
 
+  const [showRefuse, setShowRefuse] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowRefuse(true);
+    }, 180000);
+    return () => clearTimeout(timer);
+  }, []);
+
   const { send: sendCommit, status: sendCommitStatus } = useCacheSend("KlerosLiquid", "castCommit");
   const { send: sendVote, status: sendVoteStatus } = useCacheSend("KlerosLiquid", "castVote");
   const onJustificationChange = useCallback(({ currentTarget: { value } }) => setJustification(value), []);
@@ -763,7 +771,7 @@ export default function CaseDetailsCard({ ID }) {
           )}
         </div>
       )}
-      {dispute && Number(dispute.period) < "3" && !votesData.voted && (
+      {showRefuse && dispute && Number(dispute.period) < "3" && !votesData.voted && (
         <>
           <div style={{ marginTop: "32px" }}>
             If the dispute is failing to load and appears to be broken it is advised to refuse to arbitrate. Please cast


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new state variable to manage the visibility of a message regarding refusing to arbitrate in the `CaseDetailsCard` component. It also updates the `package.json` to specify a new `packageManager` version.

### Detailed summary
- Updated `package.json` to set `packageManager` to `yarn@1.22.22`.
- Added a state variable `showRefuse` and a corresponding `useEffect` to manage its visibility after a 3-minute timer.
- Modified the rendering condition to display the refuse message based on `showRefuse`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->