### PR TITLE
Fix: add adblock mention in refuse to arbitrate text

### DIFF
--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -178,7 +178,7 @@ const funcs = {
     }
     return {
       description:
-        "In case you have an AdBlock enabled, please disable it and refresh the page. It maybe preventing the correct working of the page. If that's not the case, the data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.",
+        "In case you have an AdBlock enabled, please disable it and refresh the page. It may be preventing the correct working of the page. If that's not the case, the data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.",
       title: "Invalid or tampered case data, refuse to arbitrate.",
     };
   },

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -178,7 +178,7 @@ const funcs = {
     }
     return {
       description:
-        "The data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.",
+        "In case you have an AdBlock enabled, please disable it and refresh the page. It maybe preventing the correct working of the page. If that's not the case, the data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.",
       title: "Invalid or tampered case data, refuse to arbitrate.",
     };
   },

--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -784,7 +784,7 @@ export default function CaseDetailsCard({ ID }) {
         <>
           <div style={{ marginTop: "32px" }}>
             If the dispute is failing to load and appears to be broken, in case you have an AdBlock enabled please
-            disable it and refresh the page as it maybe preventing the correct working of the page. If that is not the
+            disable it and refresh the page as it may be preventing the correct working of the page. If that is not the
             case, the data for this case is not formatted correctly or has been tampered since the time of its
             submission. Please refresh the page, if the problem persists it is advised to refuse to arbitrate. Please
             cast your vote using button below.

--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -780,11 +780,14 @@ export default function CaseDetailsCard({ ID }) {
           )}
         </div>
       )}
-      {showRefuse && dispute && Number(dispute.period) < "3" && !votesData.voted && (
+      {showRefuse && dispute && Number(dispute.period) < "3" && !votesData.voted && votesData.drawnInCurrentRound && (
         <>
           <div style={{ marginTop: "32px" }}>
-            If the dispute is failing to load and appears to be broken it is advised to refuse to arbitrate. Please cast
-            your vote using button below.
+            If the dispute is failing to load and appears to be broken, in case you have an AdBlock enabled please
+            disable it and refresh the page as it maybe preventing the correct working of the page. If that is not the
+            case, the data for this case is not formatted correctly or has been tampered since the time of its
+            submission. Please refresh the page, if the problem persists it is advised to refuse to arbitrate. Please
+            cast your vote using button below.
           </div>
           <Button
             style={{ color: "#4d00b4", marginTop: "16px", float: "right" }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving user guidance related to disputes when cases fail to load, particularly addressing potential issues caused by AdBlock and providing clearer instructions on how to proceed.

### Detailed summary
- Updated the `description` in `src/bootstrap/dataloader.js` to include advice about disabling AdBlock.
- Modified the condition for rendering in `src/components/case-details-card.jsx` to include `votesData.drawnInCurrentRound`.
- Enhanced the message regarding dispute loading issues with clearer instructions about AdBlock and case formatting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->