### PR TITLE
Fix: Add sepolia realitio proxy whitelist

### DIFF
--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -427,12 +427,13 @@ export default function CaseDetailsCard({ ID }) {
     if (
       metaEvidence &&
       metaEvidence.title !== "Invalid or tampered case data, refuse to arbitrate." &&
-      dispute?.arbitrated &&
-      !arbitrableWhitelist[arbitrableChainID]?.includes(dispute?.arbitrated.toLowerCase())
+      dispute?.arbitrated
     ) {
-      console.warn("Arbitrable NOT included in whitelist for evidence display: ", dispute?.arbitrated);
-    } else {
-      console.info("Arbitrable included in whitelist for evidence display: ", dispute?.arbitrated);
+      if (!arbitrableWhitelist[arbitrableChainID]?.includes(dispute?.arbitrated.toLowerCase())) {
+        console.warn("Arbitrable NOT included in whitelist for evidence display: ", dispute?.arbitrated);
+      } else {
+        console.info("Arbitrable included in whitelist for evidence display: ", dispute?.arbitrated);
+      }
     }
   }, [dispute?.arbitrated, arbitrableChainID, metaEvidence]);
 

--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -62,6 +62,7 @@ const arbitrableWhitelist = {
     "0xE620947519E8102aa625BBB4669fE317c9FffeD7",
     "0x1ec9729366e4C3eb8b8Ea776935508188051C0F4",
     "0xb994886066B17cfa0fE088C5933498B17FE66A50",
+    "0x05B942fAEcfB3924970E3A28e0F230910CEDFF45",
   ].map((address) => address.toLowerCase()),
   300: [
     "0x54C68fa979883d317C10F3cfDdc33522889d5612", // zkRealitioForeignProxy (Sepolia)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `arbitrable-whitelist.js` file by adding a new address and modifying the logic in `case-details-card.jsx` to enhance the handling of arbitrated disputes and their inclusion in the whitelist.

### Detailed summary
- Added a new address (`0x05B942fAEcfB3924970E3A28e0F230910CEDFF45`) to the whitelist in `arbitrable-whitelist.js`.
- Refactored logic in `case-details-card.jsx` to check if `dispute?.arbitrated` is included in the whitelist before logging messages.
- Adjusted console log statements for clarity based on the whitelist check.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->