### PR TITLE
chore: add unichain proxy to whitelist

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -67,6 +67,8 @@ const arbitrableWhitelist = {
   300: [
     "0x54C68fa979883d317C10F3cfDdc33522889d5612", // zkRealitioForeignProxy (Sepolia)
   ].map((address) => address.toLowerCase()),
+  130: [
+    "0x3FB8314C628E9afE7677946D3E23443Ce748Ac17", // RealitioForeignProxyUnichain
   1301: [
     "0xC10D916467aDdC02464aC98036E58644F0E50311", // RealitioForeignProxyUnichain (Sepolia)
   ].map((address) => address.toLowerCase()),

--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -69,6 +69,7 @@ const arbitrableWhitelist = {
   ].map((address) => address.toLowerCase()),
   130: [
     "0x3FB8314C628E9afE7677946D3E23443Ce748Ac17", // RealitioForeignProxyUnichain
+  ].map((address) => address.toLowerCase()),
   1301: [
     "0xC10D916467aDdC02464aC98036E58644F0E50311", // RealitioForeignProxyUnichain (Sepolia)
   ].map((address) => address.toLowerCase()),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new address for `RealitioForeignProxyUnichain` in the `src/temp/arbitrable-whitelist.js` file, ensuring it is included in the mapping of addresses.

### Detailed summary
- Added the address `0x3FB8314C628E9afE7677946D3E23443Ce748Ac17` for `RealitioForeignProxyUnichain`.
- Ensured the new address is converted to lowercase in the mapping function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->