### PR TITLE
fix: update gnosis endpoint

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -44,7 +44,7 @@
   REACT_APP_TOKEN_BRIDGE_XDAI_ADDRESS='0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d'
   REACT_APP_KLEROS_LIQUID_XDAI_BLOCK_NUMBER='16895601'
   REACT_APP_WEB3_FALLBACK_XDAI_URL='wss://rpc.eu-central-7.gateway.fm/ws/v4/gnosis/non-archival/mainnet'
-  REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL='https://rpc.eu-central-7.gateway.fm/v4/gnosis/non-archival/mainnet'
+  REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL='https://gnosis.rpc.grove.city/v1/d467263d'
   REACT_APP_WEB3_FALLBACK_ZKSYNCSEPOLIA_HTTPS_URL='https://sepolia.era.zksync.dev'
 
 [context.production.environment]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Web3 fallback URLs in the `netlify.toml` configuration file to point to new endpoints for the Gnosis network.

### Detailed summary
- Removed the old `REACT_APP_WEB3_FALLBACK_XDAI_URL` and `REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL`.
- Added new `REACT_APP_WEB3_FALLBACK_XDAI_URL` pointing to `wss://rpc.eu-central-7.gateway.fm/ws/v4/gnosis/non-archival/mainnet`.
- Added new `REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL` pointing to `https://gnosis.rpc.grove.city/v1/d467263d`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->