### PR TITLE
fix: apy for kip78

### DIFF
--- a/src/bootstrap/subgraph.js
+++ b/src/bootstrap/subgraph.js
@@ -4,3 +4,8 @@ export const displaySubgraph = {
   10200: "https://api.studio.thegraph.com/query/61738/kleros-display-chiado/version/latest",
   11155111: "https://api.studio.thegraph.com/query/61738/kleros-display-sepolia/version/latest",
 };
+
+export const klerosboardSubgraph = {
+  1: "https://api.studio.thegraph.com/query/66145/klerosboard-mainnet/version/latest",
+  100: "https://api.studio.thegraph.com/query/66145/klerosboard-gnosis/version/latest",
+};

--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -8,6 +8,7 @@ import { ReactComponent as Kleros } from "../assets/images/kleros.svg";
 import { ReactComponent as RightArrow } from "../assets/images/right-arrow.svg";
 import useChainId from "../hooks/use-chain-id";
 import ETHAmount from "./eth-amount";
+import { klerosboardSubgraph } from "../bootstrap/subgraph";
 
 const ipfsEndpoint = "https://cdn.kleros.link";
 
@@ -73,7 +74,7 @@ const chainIdToParams = {
       "Qme31g7UyrGVarRa6LLoaLSuxNGS8tWBfs7CHD5cgNmcXM/snapshot-2025-09.json",
     ],
     blockExplorerBaseUrl: "https://etherscan.io",
-    klerosboard: "https://api.studio.thegraph.com/query/66145/klerosboard-mainnet/version/latest",
+    klerosboard: klerosboardSubgraph[1],
   },
   100: {
     contractAddress: "0xf1A9589880DbF393F32A5b2d5a0054Fa10385074",
@@ -131,7 +132,7 @@ const chainIdToParams = {
       "QmUcemx5p2FVxncj9geEkT2DgqMLTjPND2VenaMdibX4zx/xdai-snapshot-2025-09.json",
     ],
     blockExplorerBaseUrl: "https://gnosisscan.io",
-    klerosboard: "https://api.studio.thegraph.com/query/66145/klerosboard-gnosis/version/latest",
+    klerosboard: klerosboardSubgraph[100],
   },
 };
 

--- a/src/helpers/rewards.js
+++ b/src/helpers/rewards.js
@@ -1,9 +1,8 @@
 import { BigNumber, ethers } from "ethers";
 import PNKAbi from "../assets/contracts/pinakion.json";
 import Web3 from "web3";
+import { klerosboardSubgraph } from "../bootstrap/subgraph";
 
-const MAINNET_SUBGRAPH_URL = "https://api.studio.thegraph.com/query/66145/klerosboard-mainnet/version/latest";
-const GNOSIS_SUBGRAPH_URL = "https://api.studio.thegraph.com/query/66145/klerosboard-gnosis/version/latest";
 const CLAIM_MODAL_URL = "https://raw.githubusercontent.com/kleros/court/master/src/components/claim-modal.js";
 
 function getTarget() {
@@ -109,7 +108,7 @@ async function getTotalStakedAllChains() {
 
   // Try mainnet subgraph first, fallback to snapshot
   try {
-    mainnetStaked = await fetchSubgraphStaked(MAINNET_SUBGRAPH_URL);
+    mainnetStaked = await fetchSubgraphStaked(klerosboardSubgraph[1]);
   } catch (mainnetError) {
     try {
       const snapshotUrls = await getLatestSnapshotUrls();
@@ -125,7 +124,7 @@ async function getTotalStakedAllChains() {
 
   // Try gnosis subgraph first, fallback to snapshot
   try {
-    gnosisStaked = await fetchSubgraphStaked(GNOSIS_SUBGRAPH_URL);
+    gnosisStaked = await fetchSubgraphStaked(klerosboardSubgraph[100]);
   } catch (gnosisError) {
     try {
       const snapshotUrls = await getLatestSnapshotUrls();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `klerosboardSubgraph` object to manage subgraph URLs and updates the `claim-modal` and `rewards` components to utilize this object. It also revises the staking target calculation and enhances the reward fetching logic.

### Detailed summary
- Added `klerosboardSubgraph` with URLs for mainnet and Gnosis.
- Updated `klerosboard` URL references in `chainIdToParams` to use `klerosboardSubgraph`.
- Modified staking target date and initial target value in `getTarget`.
- Enhanced `getLastMonthReward` to fetch and process URLs more effectively.
- Implemented functions to fetch staked amounts from subgraphs and snapshots.
- Adjusted `getStakingReward` to calculate APY based on total staked across chains.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rewards target schedule updated: start 2025-09-01, initial target 0.33, monthly increase 0.2% (0.002), cap 0.5.
  * Reward calculations are now cross-chain (mainnet + Gnosis) and compute APY for user-facing reward rates.
  * Dynamic discovery of latest snapshot sources and configured subgraph endpoints.

* **Reliability**
  * Improved fallbacks to snapshot data and aggregated staking fetches to reduce stale or missing reward values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->