### PR TITLE
chore: whitelist PoH V2 contracts on mainnet and gnosis

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -29,7 +29,7 @@ const arbitrableWhitelist = {
     "0xf65c7560d6ce320cc3a16a07f1f65aab66396b9e",
     "0xf72cfd1b34a91a64f9a98537fe63fbab7530adca",
     "0x2018038203aEE8e7a29dABd73771b0355D4F85ad",
-    "0xbE9834097A4E97689d9B667441acafb456D0480A", //PoH V2
+    "0xbE9834097A4E97689d9B667441acafb456D0480A", // PoH V2
   ].map((address) => address.toLowerCase()),
   100: [
     "0x0b928165a67df8254412483ae8c3b8cc7f2b4d36",


### PR DESCRIPTION
Whitelists the PoH V2 contracts on mainnet and gnosis so the PoH V2 evidence display iframe works properly

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `arbitrableWhitelist` in `src/temp/arbitrable-whitelist.js` by adding new addresses related to the PoH V2.

### Detailed summary
- Added the address `0xbE9834097A4E97689d9B667441acafb456D0480A` for PoH V2.
- Added the address `0xa4AC94C4fa65Bb352eFa30e3408e64F72aC857bc` for PoH V2.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded arbitrable whitelist by adding two PoH V2 addresses for Mainnet and Gnosis Chain, ensuring they are normalized for consistent matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->