### PR TITLE
chore: update Gnosis RPC

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -44,7 +44,7 @@
   REACT_APP_TOKEN_BRIDGE_XDAI_ADDRESS='0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d'
   REACT_APP_KLEROS_LIQUID_XDAI_BLOCK_NUMBER='16895601'
   REACT_APP_WEB3_FALLBACK_XDAI_URL='wss://rpc.eu-central-7.gateway.fm/ws/v4/gnosis/non-archival/mainnet'
-  REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL='https://gnosis.rpc.grove.city/v1/fdd5be46'
+  REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL='https://gnosis-mainnet.g.alchemy.com/v2/TcScxP88R7TlPSvDaJ5-V'
   REACT_APP_WEB3_FALLBACK_ZKSYNCSEPOLIA_HTTPS_URL='https://sepolia.era.zksync.dev'
 
 [context.production.environment]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `netlify.toml` configuration file, specifically changing the Web3 fallback HTTPS URL for the XDAI network to a new Alchemy endpoint.

### Detailed summary
- Updated `REACT_APP_WEB3_FALLBACK_XDAI_HTTPS_URL` from `https://gnosis.rpc.grove.city/v1/fdd5be46` to `https://gnosis-mainnet.g.alchemy.com/v2/TcScxP88R7TlPSvDaJ5-V`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production network endpoint for XDAI to improve connectivity performance and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->