### PR TITLE
fix: broken metaevidence for governor dispute 1672

### DIFF
--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -121,7 +121,7 @@ const funcs = {
 
         if (metaEvidenceJSON.dynamicScriptURI) {
           const scriptURI =
-            chainID === 1 && disputeId === "1621"
+            chainID === 1 && (disputeId === "1621" || disputeId === "1672")
               ? getHttpUri("/ipfs/Qmf1k727vP7qZv21MDB8vwL6tfVEKPCUQAiw8CTfHStkjf")
               : getHttpUri(metaEvidenceJSON.dynamicScriptURI);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the conditional logic for determining the `scriptURI` based on the `chainID` and `disputeId` values in the `src/bootstrap/dataloader.js` file.

### Detailed summary
- Modified the condition to set `scriptURI`:
  - Changed from checking only if `disputeId` is `"1621"` to checking if `disputeId` is either `"1621"` or `"1672"` when `chainID` is `1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced script loading to support additional system configurations, ensuring consistent behavior across different deployment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->