### PR TITLE
fix: iframe allow popups to escape sandbox

### DIFF
--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -692,7 +692,7 @@ export default function CaseDetailsCard({ ID }) {
                       <iframe
                         sandbox={
                           arbitrableWhitelist[arbitrableChainID]?.includes(dispute.arbitrated.toLowerCase())
-                            ? "allow-scripts allow-same-origin allow-popups"
+                            ? "allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                             : "allow-scripts"
                         }
                         title="dispute details"


### PR DESCRIPTION
Resolves #542.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `sandbox` attribute of an element in the `src/components/case-details-card.jsx` file to enhance security permissions for the sandboxed content.

### Detailed summary
- Modified the `sandbox` attribute to include `allow-popups-to-escape-sandbox` when the condition is met.
- The previous value of the `sandbox` attribute was `"allow-scripts allow-same-origin allow-popups"`.
- The new value is `"allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sandbox permissions for evidence display in whitelisted cases to allow popups to escape the sandbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->