### PR TITLE
Add arbitrable contract for seer-curate on gnosis chain to whitelist

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -58,6 +58,7 @@ const arbitrableWhitelist = {
     "0xeF2Ae6961Ec7F2105bc2693Bc32fA7b7386B2f59", // RealitioForeignArbitrationProxyWithAppeals (Ethereum)
     "0x32bcDC9776692679CfBBf8350BAd67Da13FaaA3F", // RealitioForeignArbitrationProxyWithAppeals (Ethereum)
     "0xa4AC94C4fa65Bb352eFa30e3408e64F72aC857bc", // PoH V2
+    "0x5aAF9E23A11440F8C1Ad6D2E2e5109C7e52CC672", // Seer Market registry on Curate
   ].map((address) => address.toLowerCase()),
   11155111: [
     "0x73E4F71e5ecE8d1319807DC7cd2EAA9Fda8F5182",


### PR DESCRIPTION
Due the contract not whitelisted dispute 720 on gnosis is not loading properly. This adds contract to whitelist.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new address for the Seer Market registry on Curate to the `arbitrable-whitelist` in the `src/temp/arbitrable-whitelist.js` file, ensuring it is included in the list of recognized addresses.

### Detailed summary
- Added the address `0x5aAF9E23A11440F8C1Ad6D2E2e5109C7e52CC672` for the Seer Market registry on Curate to the whitelist.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new arbitrable contract address to the supported whitelist, enabling integration with a Seer contract for the Curate application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->