### PR TITLE
chore: whitelist kleros tokens registry

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -59,6 +59,7 @@ const arbitrableWhitelist = {
     "0x32bcDC9776692679CfBBf8350BAd67Da13FaaA3F", // RealitioForeignArbitrationProxyWithAppeals (Ethereum)
     "0xa4AC94C4fa65Bb352eFa30e3408e64F72aC857bc", // PoH V2
     "0x5aAF9E23A11440F8C1Ad6D2E2e5109C7e52CC672", // Seer Market registry on Curate
+    "0xeE1502e29795Ef6C2D60F8D7120596abE3baD990", // Kleros Tokens registry on Curate
   ].map((address) => address.toLowerCase()),
   11155111: [
     "0x73E4F71e5ecE8d1319807DC7cd2EAA9Fda8F5182",


### PR DESCRIPTION
Resolves #554.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `arbitrable-whitelist.js` file by adding a new entry for the Kleros Tokens registry on Curate, ensuring that the addresses are consistently formatted in lowercase.

### Detailed summary
- Added the address `0xeE1502e29795Ef6C2D60F8D7120596abE3baD990` for the Kleros Tokens registry on Curate to the whitelist.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->