### PR TITLE
chore: remove hardcoded subgraph urls

### DIFF
--- a/src/bootstrap/subgraph.js
+++ b/src/bootstrap/subgraph.js
@@ -1,8 +1,8 @@
 export const displaySubgraph = {
   1: process.env.REACT_APP_SUBGRAPH_MAINNET_DISPLAY,
   100: process.env.REACT_APP_SUBGRAPH_GNOSIS_DISPLAY,
-  10200: "https://api.studio.thegraph.com/query/61738/kleros-display-chiado/version/latest",
-  11155111: "https://api.studio.thegraph.com/query/61738/kleros-display-sepolia/version/latest",
+  10200: process.env.REACT_APP_SUBGRAPH_CHIADO_DISPLAY,
+  11155111: process.env.REACT_APP_SUBGRAPH_SEPOLIA_DISPLAY,
 };
 
 export const klerosboardSubgraph = {


### PR DESCRIPTION
Resolves #557.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `src/bootstrap/subgraph.js` file to replace hardcoded URLs with environment variables for subgraph displays, improving configurability and security.

### Detailed summary
- Removed hardcoded URL for `chiado` subgraph: `"https://api.studio.thegraph.com/query/61738/kleros-display-chiado/version/latest"`
- Removed hardcoded URL for `sepolia` subgraph: `"https://api.studio.thegraph.com/query/61738/kleros-display-sepolia/version/latest"`
- Added environment variable for `chiado` display: `process.env.REACT_APP_SUBGRAPH_CHIADO_DISPLAY`
- Added environment variable for `sepolia` display: `process.env.REACT_APP_SUBGRAPH_SEPOLIA_DISPLAY`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated subgraph endpoint configuration to use environment variables instead of hardcoded values for Chiado and Sepolia networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->