### PR TITLE
fix:  mobile dApp browsers connection redundancy

### DIFF
--- a/src/bootstrap/app.js
+++ b/src/bootstrap/app.js
@@ -46,7 +46,14 @@ export default function App() {
         //Wallets found, check for existing connection
         const provider = getLastConnectedWalletProvider();
         if (provider?.request) {
-          const accounts = await provider.request({ method: "eth_accounts" });
+          let accounts = await provider.request({ method: "eth_accounts" });
+
+          //Some mobile dApp browsers (e.g. TrustWallet) don't persist connections across page reloads, which causes problems connecting as we're forced to reload because of drizzle.
+          //So, if we have a stored wallet ID but eth_accounts returns empty, request accounts to re-establish the connection.
+          if (!accounts || accounts.length === 0) {
+            accounts = await provider.request({ method: "eth_requestAccounts" });
+          }
+
           if (accounts && accounts.length > 0) {
             handleWalletConnected(provider);
             return;


### PR DESCRIPTION
Resolves #562.

<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the handling of wallet connections in mobile dApp browsers by adding a fallback mechanism to request accounts if the initial call returns no accounts. This addresses issues with connection persistence across page reloads.

### Detailed summary
- Changed the declaration of `accounts` from `const` to `let` to allow reassignment.
- Added a comment explaining the issue with mobile dApp browsers not persisting connections.
- Introduced a conditional check to request accounts using `eth_requestAccounts` if `eth_accounts` returns empty.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet connection recovery for mobile dApp browsers by implementing a robust fallback mechanism. The app now automatically attempts to re-establish connections with previously connected wallets if the initial connection is lost after a page reload, ensuring more reliable and persistent wallet connectivity across user sessions and device restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->