### PR TITLE
feat: allow users to unsubscribe from notifications

### DIFF
--- a/src/bootstrap/atlas-api.js
+++ b/src/bootstrap/atlas-api.js
@@ -248,6 +248,18 @@ export const addUser = async (email) => {
   return data?.addUser === true;
 };
 
+//Delete user
+export const deleteUser = async () => {
+  const data = await graphqlRequest(
+    `mutation deleteUser {
+      deleteUser
+    }`,
+    {},
+    true
+  );
+  return data?.deleteUser === true;
+};
+
 //Update user email
 export const updateEmail = async (newEmail) => {
   const data = await graphqlRequest(

--- a/src/components/email-confirmation.js
+++ b/src/components/email-confirmation.js
@@ -16,6 +16,10 @@ const Container = styled.div`
 const StyledAlert = styled(Alert)`
   max-width: 500px;
   height: fit-content;
+
+  .ant-alert-message {
+    color: ${({ theme }) => theme.textPrimary};
+  }
 `;
 
 export default function EmailConfirmation() {

--- a/src/components/notification-settings.js
+++ b/src/components/notification-settings.js
@@ -144,7 +144,14 @@ const NotificationSettingsContent = ({
             </Form.Item>
 
             <Button
-              disabled={hasErrors || isUpdatingEmail || isUnsubscribing || !emailHasChanged || !canUpdateEmail}
+              disabled={
+                hasErrors ||
+                isUpdatingEmail ||
+                isResendingVerification ||
+                isUnsubscribing ||
+                !emailHasChanged ||
+                !canUpdateEmail
+              }
               htmlType="submit"
               loading={isUpdatingEmail}
               type="primary"
@@ -191,7 +198,7 @@ const NotificationSettingsContent = ({
                   size="small"
                   onClick={onResendVerification}
                   loading={isResendingVerification}
-                  disabled={!canUpdateEmail}
+                  disabled={!canUpdateEmail || isUpdatingEmail || isUnsubscribing}
                 >
                   Resend verification email
                 </Button>
@@ -326,7 +333,7 @@ const NotificationSettings = Form.create()(({ form }) => {
 
   const handleResendVerification = useCallback(async () => {
     const email = userData?.email;
-    if (!email || !isAuthenticated || isResendingVerification) return;
+    if (!email || !isAuthenticated || isResendingVerification || isUpdatingEmail || isUnsubscribing) return;
 
     //Clear errors and set loading state
     setIsResendingVerification(true);
@@ -342,12 +349,12 @@ const NotificationSettings = Form.create()(({ form }) => {
     } finally {
       setIsResendingVerification(false);
     }
-  }, [userData, isAuthenticated, isResendingVerification, drizzleState.account]);
+  }, [userData, isAuthenticated, isResendingVerification, isUpdatingEmail, isUnsubscribing, drizzleState.account]);
 
   const onSubmit = useCallback(
     async (e) => {
       e.preventDefault();
-      if (isUpdatingEmail || !isAuthenticated) return;
+      if (isUpdatingEmail || isResendingVerification || isUnsubscribing || !isAuthenticated) return;
 
       form.validateFieldsAndScroll(async (err, values) => {
         if (!err) {
@@ -381,7 +388,7 @@ const NotificationSettings = Form.create()(({ form }) => {
         }
       });
     },
-    [form, isAuthenticated, isUpdatingEmail, drizzleState.account, userData]
+    [form, isAuthenticated, isUpdatingEmail, isResendingVerification, isUnsubscribing, drizzleState.account, userData]
   );
 
   return (

--- a/src/components/notification-settings.js
+++ b/src/components/notification-settings.js
@@ -9,6 +9,7 @@ import {
   addUser,
   authenticateUser,
   clearAuthData,
+  deleteUser,
   fetchUser,
   getAuthToken,
   isTokenForAccount,
@@ -52,6 +53,16 @@ const StyledAlertContainer = styled.div`
   gap: 8px;
 `;
 
+const StyledAlert = styled(Alert)`
+  .ant-alert-message {
+    color: ${({ theme }) => theme.textPrimary};
+  }
+
+  .anticon-close {
+    color: ${({ theme }) => theme.textSecondary};
+  }
+`;
+
 const NotificationSettingsContent = ({
   account,
   form,
@@ -68,6 +79,9 @@ const NotificationSettingsContent = ({
   emailHasChanged,
   onResendVerification,
   isResendingVerification,
+  onUnsubscribe,
+  isUnsubscribing,
+  unsubscribeError,
 }) => {
   const userEmail = userData?.email || "";
   const isEmailVerified = userData?.isEmailVerified || false;
@@ -102,7 +116,7 @@ const NotificationSettingsContent = ({
         <Button type="primary" onClick={onSignIn} loading={isSigningIn} block>
           Sign In
         </Button>
-        {signInError && <Alert closable message={signInError} type="error" />}
+        {signInError && <StyledAlert closable message={signInError} type="error" />}
       </StyledForm>
     );
   }
@@ -128,8 +142,9 @@ const NotificationSettingsContent = ({
                 ],
               })(<Input placeholder="Email" />)}
             </Form.Item>
+
             <Button
-              disabled={hasErrors || isUpdatingEmail || !emailHasChanged || !canUpdateEmail}
+              disabled={hasErrors || isUpdatingEmail || isUnsubscribing || !emailHasChanged || !canUpdateEmail}
               htmlType="submit"
               loading={isUpdatingEmail}
               type="primary"
@@ -137,6 +152,20 @@ const NotificationSettingsContent = ({
             >
               Save
             </Button>
+
+            {userEmail && (
+              <Button
+                className="mt-2"
+                type="danger"
+                htmlType="button"
+                block
+                loading={isUnsubscribing}
+                disabled={isUnsubscribing}
+                onClick={onUnsubscribe}
+              >
+                Unsubscribe
+              </Button>
+            )}
           </>
         )}
       </Skeleton>
@@ -145,7 +174,7 @@ const NotificationSettingsContent = ({
 
       <StyledAlertContainer>
         {!isEmailVerified && userEmail && (
-          <Alert
+          <StyledAlert
             message="Email not verified"
             type="warning"
             closable
@@ -170,10 +199,11 @@ const NotificationSettingsContent = ({
             }
           />
         )}
-        {updateEmailError && !isUpdatingEmail && <Alert closable message={updateEmailError} type="error" />}
+        {updateEmailError && !isUpdatingEmail && <StyledAlert closable message={updateEmailError} type="error" />}
         {updateEmailSuccess && !isUpdatingEmail && !updateEmailError && (
-          <Alert closable message="Saved settings." type="success" />
+          <StyledAlert closable message="Saved settings." type="success" />
         )}
+        {unsubscribeError && !isUnsubscribing && <StyledAlert closable message={unsubscribeError} type="error" />}
       </StyledAlertContainer>
     </StyledForm>
   );
@@ -195,6 +225,9 @@ NotificationSettingsContent.propTypes = {
   emailHasChanged: PropTypes.bool.isRequired,
   onResendVerification: PropTypes.func.isRequired,
   isResendingVerification: PropTypes.bool.isRequired,
+  onUnsubscribe: PropTypes.func.isRequired,
+  isUnsubscribing: PropTypes.bool.isRequired,
+  unsubscribeError: PropTypes.string,
 };
 
 const NotificationSettings = Form.create()(({ form }) => {
@@ -206,9 +239,11 @@ const NotificationSettings = Form.create()(({ form }) => {
   const [isSigningIn, setIsSigningIn] = useState(false);
   const [isUpdatingEmail, setIsUpdatingEmail] = useState(false);
   const [isResendingVerification, setIsResendingVerification] = useState(false);
+  const [isUnsubscribing, setIsUnsubscribing] = useState(false);
   const [updateEmailError, setUpdateEmailError] = useState(null);
   const [updateEmailSuccess, setUpdateEmailSuccess] = useState(false);
   const [signInError, setSignInError] = useState(null);
+  const [unsubscribeError, setUnsubscribeError] = useState(null);
 
   //Check if user is authenticated and has a valid token for the current connected wallet
   const token = getAuthToken();
@@ -267,6 +302,24 @@ const NotificationSettings = Form.create()(({ form }) => {
       setIsSigningIn(false);
     }
   }, [drizzle.web3, drizzleState.account]);
+
+  const handleUnsubscribe = useCallback(async () => {
+    if (!isAuthenticated || !userEmail) return;
+
+    //Clear errors and set loading state
+    setIsUnsubscribing(true);
+    setUnsubscribeError(null);
+
+    try {
+      await deleteUser();
+      clearAuthData();
+      mutate(["atlas-user", drizzleState.account.toLowerCase()]);
+    } catch (err) {
+      setUnsubscribeError(err?.message || "Failed to unsubscribe");
+    } finally {
+      setIsUnsubscribing(false);
+    }
+  }, [isAuthenticated, drizzleState.account, userEmail]);
 
   const handleResendVerification = useCallback(async () => {
     const email = userData?.email;
@@ -348,6 +401,9 @@ const NotificationSettings = Form.create()(({ form }) => {
           emailHasChanged={emailHasChanged}
           onResendVerification={handleResendVerification}
           isResendingVerification={isResendingVerification}
+          onUnsubscribe={handleUnsubscribe}
+          isUnsubscribing={isUnsubscribing}
+          unsubscribeError={unsubscribeError}
         />
       }
       placement="bottomRight"

--- a/src/components/notification-settings.js
+++ b/src/components/notification-settings.js
@@ -160,7 +160,7 @@ const NotificationSettingsContent = ({
                 htmlType="button"
                 block
                 loading={isUnsubscribing}
-                disabled={isUnsubscribing}
+                disabled={isUnsubscribing || isUpdatingEmail || isResendingVerification}
                 onClick={onUnsubscribe}
               >
                 Unsubscribe
@@ -304,14 +304,17 @@ const NotificationSettings = Form.create()(({ form }) => {
   }, [drizzle.web3, drizzleState.account]);
 
   const handleUnsubscribe = useCallback(async () => {
-    if (!isAuthenticated || !userEmail) return;
+    if (!isAuthenticated || !userEmail || isUpdatingEmail || isResendingVerification || isUnsubscribing) return;
 
     //Clear errors and set loading state
     setIsUnsubscribing(true);
     setUnsubscribeError(null);
 
     try {
-      await deleteUser();
+      const deleted = await deleteUser();
+      if (!deleted) {
+        throw new Error("Failed to unsubscribe");
+      }
       clearAuthData();
       mutate(["atlas-user", drizzleState.account.toLowerCase()]);
     } catch (err) {
@@ -319,7 +322,7 @@ const NotificationSettings = Form.create()(({ form }) => {
     } finally {
       setIsUnsubscribing(false);
     }
-  }, [isAuthenticated, drizzleState.account, userEmail]);
+  }, [isAuthenticated, drizzleState.account, userEmail, isUpdatingEmail, isResendingVerification, isUnsubscribing]);
 
   const handleResendVerification = useCallback(async () => {
     const email = userData?.email;

--- a/src/components/notification-settings.js
+++ b/src/components/notification-settings.js
@@ -1,4 +1,4 @@
-import { Alert, Button, Divider, Form, Input, Popover, Skeleton } from "antd";
+import { Alert, Button, Divider, Form, Input, message, Popover, Skeleton } from "antd";
 import React, { useCallback, useEffect, useState } from "react";
 import { drizzleReactHooks } from "@drizzle/react-plugin";
 import { ReactComponent as Mail } from "../assets/images/mail.svg";
@@ -322,6 +322,7 @@ const NotificationSettings = Form.create()(({ form }) => {
       if (!deleted) {
         throw new Error("Failed to unsubscribe");
       }
+      message.success("You have been unsubscribed from email notifications.");
       clearAuthData();
       mutate(["atlas-user", drizzleState.account.toLowerCase()]);
     } catch (err) {


### PR DESCRIPTION
Resolves #568. 
Also includes some minor fixes for dark/light theme colors.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality for user email management, including a new `deleteUser` mutation, enhances the `NotificationSettings` component with unsubscribe capabilities, and improves styling for alerts.

### Detailed summary
- Added `deleteUser` mutation in `src/bootstrap/atlas-api.js`.
- Implemented unsubscribe button and logic in `NotificationSettings`.
- Enhanced alert styling with `StyledAlert` in `src/components/notification-settings.js`.
- Updated prop types for unsubscribe handling in `NotificationSettings`.
- Modified button states for various loading conditions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Unsubscribe (account removal) option in Notification Settings with a dedicated button, loading/disabled states, confirmation and error feedback, and automatic sign-out/cleanup after completion.
  * Notification flows now disable relevant actions while unsubscribing or updating to prevent conflicts.

* **Style**
  * Unified alert styling for consistent themed text color across notification-related UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->