### PR TITLE
fix: prevent unnecessary wallet popups

### DIFF
--- a/src/bootstrap/app.js
+++ b/src/bootstrap/app.js
@@ -50,7 +50,10 @@ export default function App() {
 
           //Some mobile dApp browsers (e.g. TrustWallet) don't persist connections across page reloads, which causes problems connecting as we're forced to reload because of drizzle.
           //So, if we have a stored wallet ID but eth_accounts returns empty, request accounts to re-establish the connection.
-          if (!accounts || accounts.length === 0) {
+          //Only do this on mobile browsers to avoid triggering wallet extension unlock popups on desktop.
+          //Detection method is based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Browser_detection_using_the_user_agent
+          const isMobile = /Mobi/i.test(navigator.userAgent);
+          if (isMobile && (!accounts || accounts.length === 0)) {
             accounts = await provider.request({ method: "eth_requestAccounts" });
           }
 


### PR DESCRIPTION
Resolves #571.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of Ethereum account requests in mobile dApp browsers. It ensures that account requests are only made on mobile devices when no accounts are detected, preventing unnecessary prompts on desktop browsers.

### Detailed summary
- Added detection for mobile browsers using `navigator.userAgent`.
- Modified the condition to request accounts only if the browser is mobile and no accounts are available.
- Updated comments to clarify the reasoning behind these changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet auto-reconnect functionality to request account access on mobile devices only, reducing unnecessary prompts on desktop browsers and enhancing overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->