### PR TITLE
fix: ensure switch to mainnet modal works without a connected wallet

### DIFF
--- a/src/components/network-status.js
+++ b/src/components/network-status.js
@@ -31,7 +31,7 @@ function SwitchChainMenu() {
     if (targetChainId === chainId) return; // Already on this chain
 
     if (account === VIEW_ONLY_ADDRESS) {
-      setRequiredChainId(targetChainId, { location: "/" });
+      setRequiredChainId(targetChainId);
       window.location.reload();
     } else {
       try {

--- a/src/containers/case.js
+++ b/src/containers/case.js
@@ -34,6 +34,7 @@ export default function Case() {
 
   //Do what was done in app.js loadable() here, so we can avoid using a fallback drizzle there
   const [error, setError] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(true);
 
   useEffect(() => {
     //Avoid setting state after component is unmounted
@@ -105,10 +106,15 @@ export default function Case() {
     );
   }, [disputeData.deadline]);
 
+  useEffect(() => {
+    if (isDisputeTooOld && chainId !== 1) setIsModalOpen(true);
+  }, [isDisputeTooOld, chainId]);
+
   //Fallback to the 404 like the loadable() in app.js used to do
   if (error) return <C404 />;
 
   async function handleChainSwitchToMainnet() {
+    setIsModalOpen(false);
     if (drizzleState.account === VIEW_ONLY_ADDRESS) {
       setRequiredChainId(1);
       window.location.reload();
@@ -129,8 +135,8 @@ export default function Case() {
       return (
         <Modal
           title="Dispute Not Found"
-          visible={true}
-          closable={true}
+          visible={isModalOpen}
+          onCancel={() => setIsModalOpen(false)}
           footer={[
             <Button key="switch" type="primary" onClick={handleChainSwitchToMainnet}>
               Switch to Mainnet

--- a/src/containers/case.js
+++ b/src/containers/case.js
@@ -6,7 +6,7 @@ import CaseDetailsCard from "../components/case-details-card.jsx";
 import ETHAmount from "../components/eth-amount";
 import TimeAgo from "../components/time-ago";
 import TopBanner from "../components/top-banner";
-import RequiredChainIdGateway from "../components/required-chain-id-gateway";
+import RequiredChainIdGateway, { useSetRequiredChainId } from "../components/required-chain-id-gateway";
 import RequiredChainIdModal from "../components/required-chain-id-modal";
 import styled from "styled-components/macro";
 import { VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
@@ -56,6 +56,7 @@ export default function Case() {
   const dispute = useCacheCall("KlerosLiquid", "disputes", ID);
   const dispute2 = useCacheCall("KlerosLiquid", "getDispute", ID);
   const chainId = useChainId();
+  const setRequiredChainId = useSetRequiredChainId();
   const draws = useGetDraws(chainId, `address: "${drizzleState.account}", disputeID: ${ID}`);
 
   const disputeData = useCacheCall(["KlerosLiquid"], (call) => {
@@ -108,13 +109,18 @@ export default function Case() {
   if (error) return <C404 />;
 
   async function handleChainSwitchToMainnet() {
-    try {
-      await window.ethereum.request({
-        method: "wallet_switchEthereumChain",
-        params: [{ chainId: "0x1" }],
-      });
-    } catch (error) {
-      console.error("Error switching chains:", error);
+    if (drizzleState.account === VIEW_ONLY_ADDRESS) {
+      setRequiredChainId(1);
+      window.location.reload();
+    } else {
+      try {
+        await window.ethereum.request({
+          method: "wallet_switchEthereumChain",
+          params: [{ chainId: "0x1" }],
+        });
+      } catch (error) {
+        console.error("Error switching chains:", error);
+      }
     }
   }
 
@@ -124,7 +130,7 @@ export default function Case() {
         <Modal
           title="Dispute Not Found"
           visible={true}
-          closable={false}
+          closable={true}
           footer={[
             <Button key="switch" type="primary" onClick={handleChainSwitchToMainnet}>
               Switch to Mainnet

--- a/src/containers/cases.js
+++ b/src/containers/cases.js
@@ -4,6 +4,7 @@ import { drizzleReactHooks } from "@drizzle/react-plugin";
 import CaseCard from "../components/case-card";
 import TopBanner from "../components/top-banner";
 import RequiredChainIdGateway from "../components/required-chain-id-gateway";
+import RequiredChainIdModal from "../components/required-chain-id-modal";
 import styled from "styled-components/macro";
 import { VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
 import useChainId from "../hooks/use-chain-id";
@@ -92,9 +93,8 @@ export default function Cases() {
   const filteredDisputes = disputes[["votePending", "active", "executed"][filter]];
   const sortedDisputes = [...filteredDisputes].sort((a, b) => a.status - b.status);
 
-  //RequiredChainIdGateway is used here just to clean the requiredChainId query parameter when the user is on the wrong network
-  return (
-    <RequiredChainIdGateway>
+  const content = (
+    <>
       <TopBanner
         description="Select a case you have been drawn in, study the evidence, and vote."
         extra={
@@ -124,6 +124,19 @@ export default function Cases() {
           )}
         </Row>
       </Spin>
+    </>
+  );
+
+  return (
+    <RequiredChainIdGateway
+      renderOnMismatch={({ requiredChainId }) => (
+        <>
+          {content}
+          <RequiredChainIdModal requiredChainId={requiredChainId} />
+        </>
+      )}
+    >
+      {content}
     </RequiredChainIdGateway>
   );
 }

--- a/src/containers/cases.js
+++ b/src/containers/cases.js
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from "react";
 import { drizzleReactHooks } from "@drizzle/react-plugin";
 import CaseCard from "../components/case-card";
 import TopBanner from "../components/top-banner";
+import RequiredChainIdGateway from "../components/required-chain-id-gateway";
 import styled from "styled-components/macro";
 import { VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
 import useChainId from "../hooks/use-chain-id";
@@ -91,8 +92,9 @@ export default function Cases() {
   const filteredDisputes = disputes[["votePending", "active", "executed"][filter]];
   const sortedDisputes = [...filteredDisputes].sort((a, b) => a.status - b.status);
 
+  //RequiredChainIdGateway is used here just to clean the requiredChainId query parameter when the user is on the wrong network
   return (
-    <>
+    <RequiredChainIdGateway>
       <TopBanner
         description="Select a case you have been drawn in, study the evidence, and vote."
         extra={
@@ -122,7 +124,7 @@ export default function Cases() {
           )}
         </Row>
       </Spin>
-    </>
+    </RequiredChainIdGateway>
   );
 }
 


### PR DESCRIPTION
Resolves #573.

Also changes the logic of switching chains so users can stay on the same page they were before.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of chain ID requirements in the application, adding modals for user guidance, and improving the user experience when switching chains.

### Detailed summary
- In `src/components/network-status.js`, removed the `location` parameter from `setRequiredChainId`.
- In `src/containers/cases.js`, added `RequiredChainIdGateway` and `RequiredChainIdModal` to manage chain ID mismatches.
- Wrapped main content in `RequiredChainIdGateway` to display a modal when the chain ID is incorrect.
- In `src/containers/case.js`, added `useSetRequiredChainId` and a state for modal visibility.
- Implemented a `useEffect` to open the modal if the dispute is too old and the chain ID is incorrect.
- Updated the modal visibility and cancel functionality to reflect the new state management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chain switching for view-only accounts so the app updates and reloads correctly.
  * "Dispute Not Found" modal now respects visibility state and can be dismissed by users.

* **Improvements**
  * Wrapped cases view with chain requirement gating so the list and banner behave consistently when on the wrong network.
  * Streamlined modal and chain-switch flow for a more reliable user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->