### PR TITLE
fix: rabby mainnet wallet connection

### DIFF
--- a/src/bootstrap/drizzle.js
+++ b/src/bootstrap/drizzle.js
@@ -93,6 +93,13 @@ function createDrizzle({ fallbackChainId, customProvider } = {}) {
 
   if (customProvider) {
     web3Instance = customProvider instanceof Web3 ? customProvider : new Web3(customProvider);
+
+    //Some wallets (e.g. Rabby on mainnet) might cause problems obtaining the chain ID, which will
+    //cascade into problems getting the contracts on a given chain, causing the app to crash.
+    //This is because Drizzle defaults to `web3.eth.net.getId()` to bind contract addresses for a specific chain,
+    //and on failure there are no contracts, causing crashes in useCacheCall consumers, for instance.
+    //Binding `getId` to `getChainId`, which is more recent and reliable on providers, works around this.
+    web3Instance.eth.net.getId = web3Instance.eth.getChainId.bind(web3Instance.eth);
   } else {
     const fallbackUrl = chainIdToFallbackUrl[fallbackChainId];
     if (fallbackUrl) {

--- a/src/containers/case.js
+++ b/src/containers/case.js
@@ -10,6 +10,7 @@ import RequiredChainIdGateway, { useSetRequiredChainId } from "../components/req
 import RequiredChainIdModal from "../components/required-chain-id-modal";
 import styled from "styled-components/macro";
 import { VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
+import { requestSwitchChain } from "../api/side-chain";
 import useChainId from "../hooks/use-chain-id";
 import useGetDraws from "../hooks/use-get-draws";
 import { chainIdToNetworkName } from "../helpers/networks";
@@ -120,10 +121,7 @@ export default function Case() {
       window.location.reload();
     } else {
       try {
-        await window.ethereum.request({
-          method: "wallet_switchEthereumChain",
-          params: [{ chainId: "0x1" }],
-        });
+        await requestSwitchChain(drizzle.web3.currentProvider, 1);
       } catch (error) {
         console.error("Error switching chains:", error);
       }


### PR DESCRIPTION
Resolves #579.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of Ethereum chain switching and enhancing the reliability of the `web3` instance in the `drizzle` setup.

### Detailed summary
- Added `requestSwitchChain` to handle Ethereum chain switching in the `Case` component.
- Replaced the direct Ethereum chain switch request with a more reliable method using `requestSwitchChain`.
- Updated `drizzle.js` to bind `web3.eth.net.getId` to `web3.eth.getChainId`, improving chain ID retrieval reliability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to some blockchain providers by making chain ID detection more resilient, preventing crashes during contract interactions.
  * More reliable wallet chain switching to Ethereum mainnet, reducing failed switch attempts and improving connection stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kleros/court/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->