### PR TITLE
fix: poh cases evidence mismatch

### DIFF
--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -276,7 +276,7 @@ const normalizeEvidenceJSON = (json) => {
   const normalized = { ...json };
 
   //Many PoH cases have an evidence format mismatch.
-  //It uses the `evidence` field for the attached file URI instead of the fileURI field directly.
+  //It uses the `evidence` field for the attached file URI instead of the `fileURI` field directly.
   if (!normalized.fileURI && normalized.evidence) {
     normalized.fileURI = normalized.evidence;
   }

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -272,7 +272,7 @@ export const useDataloader = Object.keys(dataloaders).reduce((acc, f) => {
 }, {});
 
 const normalizeEvidenceJSON = (json) => {
-  if (!json) return json;
+  if (!json || typeof json !== "object" || Array.isArray(json)) return json;
   const normalized = { ...json };
 
   //Many PoH cases have an evidence format mismatch.

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -271,6 +271,18 @@ export const useDataloader = Object.keys(dataloaders).reduce((acc, f) => {
   return acc;
 }, {});
 
+const normalizeEvidenceJSON = (json) => {
+  if (!json) return json;
+  const normalized = { ...json };
+
+  //Many PoH cases have an evidence format mismatch.
+  //It uses the `evidence` field for the attached file URI instead of the fileURI field directly.
+  if (!normalized.fileURI && normalized.evidence) {
+    normalized.fileURI = normalized.evidence;
+  }
+  return normalized;
+};
+
 const evidenceFetcher = async ([subgraph, disputeId]) => {
   const evidence = await axios
     .post(
@@ -305,8 +317,9 @@ const evidenceFetcher = async ([subgraph, disputeId]) => {
             if (fileRes.status !== 200)
               throw new Error(`HTTP Error: Unable to fetch file at ${uri}. Returned status code ${fileRes.status}`);
 
+            const evidenceJSON = normalizeEvidenceJSON(fileRes.data);
             return {
-              evidenceJSON: fileRes.data,
+              evidenceJSON,
               submittedAt: evidenceItem.creationTime,
               submittedBy: evidenceItem.sender,
             };


### PR DESCRIPTION
Resolves #581.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new function `normalizeEvidenceJSON` to standardize the format of evidence data retrieved from a file. It ensures that if the `fileURI` is missing, it will populate it with the value from the `evidence` field, addressing format mismatches.

### Detailed summary
- Added function `normalizeEvidenceJSON` to normalize evidence JSON input.
- Checks if input is valid and converts it if necessary.
- If `fileURI` is absent, assigns value from `evidence`.
- Updated `evidenceFetcher` to use the normalized evidence data instead of raw data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where some evidence items lacked required fields, ensuring missing identifiers are inferred so all evidence displays consistently throughout the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kleros/court/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->