### PR TITLE
feat: add monthly totals to staking rewards

### DIFF
--- a/public/staking-rewards.html
+++ b/public/staking-rewards.html
@@ -140,17 +140,22 @@
       // Spreadsheet-like table component
       const PAGE_SIZE = 100;
 
-      function SpreadsheetTable({ rows, columns }) {
+      function SpreadsheetTable({ rows, columns, noun = "address", nounPlural = "addresses" }) {
         const [sortCol, setSortCol] = useState(null);
         const [sortAsc, setSortAsc] = useState(false);
         const [search, setSearch] = useState("");
         const [page, setPage] = useState(0);
 
+        const filterKey = columns[0].key;
         const filtered = useMemo(() => {
           if (!search) return rows;
           const q = search.toLowerCase();
-          return rows.filter((r) => r.Address.toLowerCase().includes(q));
-        }, [rows, search]);
+          return rows.filter((r) =>
+            String(r[filterKey] ?? "")
+              .toLowerCase()
+              .includes(q)
+          );
+        }, [rows, search, filterKey]);
 
         const sorted = useMemo(() => {
           if (sortCol === null) return filtered;
@@ -185,7 +190,7 @@
               <input
                 className="search-input"
                 type="text"
-                placeholder="Search address..."
+                placeholder={"Search " + noun + "..."}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 style={{
@@ -201,7 +206,7 @@
                 }}
               />
               <span style={{ fontSize: 11, color: "#6c6c8a", whiteSpace: "nowrap" }}>
-                {filtered.length.toLocaleString()} address{filtered.length !== 1 ? "es" : ""}
+                {filtered.length.toLocaleString()} {filtered.length !== 1 ? nounPlural : noun}
               </span>
             </div>
             <div style={{ overflowX: "auto", borderRadius: 8, border: "1px solid rgba(108,92,231,0.15)" }}>
@@ -474,11 +479,21 @@
 
           setMonthData(md);
           setGrandTotals(gt);
-          setTabList(["Summary", ...sorted]);
+          setTabList(["Summary", "Monthly Totals", ...sorted]);
           setActiveTab("Summary");
           setErrors(errs);
           setPhase("done");
         }
+
+        // Months sorted newest-first (matches the tab order)
+        const sortedMonths = useMemo(() => {
+          if (!monthData) return [];
+          return Object.keys(monthData).sort((a, b) => {
+            if (a === "2021-01 & 02") return 1;
+            if (b === "2021-01 & 02") return -1;
+            return b.localeCompare(a);
+          });
+        }, [monthData]);
 
         // Build rows for current tab
         const currentRows = useMemo(() => {
@@ -492,6 +507,21 @@
                 "Grand Total": Math.round((t.mainnet + t.gnosis) * 100) / 100,
               }))
               .sort((a, b) => b["Grand Total"] - a["Grand Total"]);
+          }
+          if (activeTab === "Monthly Totals") {
+            return sortedMonths.map((label) => {
+              const { mainnet, gnosis } = monthData[label];
+              let m = 0,
+                g = 0;
+              for (const v of Object.values(mainnet)) m += v;
+              for (const v of Object.values(gnosis)) g += v;
+              return {
+                Month: label,
+                "Mainnet PNK": Math.round(m * 100) / 100,
+                "Gnosis PNK": Math.round(g * 100) / 100,
+                "Total PNK": Math.round((m + g) * 100) / 100,
+              };
+            });
           }
           const { mainnet, gnosis } = monthData[activeTab] || { mainnet: {}, gnosis: {} };
           const allAddrs = new Set([...Object.keys(mainnet), ...Object.keys(gnosis)]);
@@ -507,7 +537,7 @@
               };
             })
             .sort((a, b) => (b["Total PNK"] || 0) - (a["Total PNK"] || 0));
-        }, [activeTab, grandTotals, monthData]);
+        }, [activeTab, grandTotals, monthData, sortedMonths]);
 
         const currentColumns = useMemo(() => {
           if (activeTab === "Summary")
@@ -516,6 +546,13 @@
               { key: "Mainnet PNK", label: "Mainnet PNK", align: "right" },
               { key: "Gnosis PNK", label: "Gnosis PNK", align: "right" },
               { key: "Grand Total", label: "Grand Total", align: "right" },
+            ];
+          if (activeTab === "Monthly Totals")
+            return [
+              { key: "Month", label: "Month", align: "left" },
+              { key: "Mainnet PNK", label: "Mainnet PNK", align: "right" },
+              { key: "Gnosis PNK", label: "Gnosis PNK", align: "right" },
+              { key: "Total PNK", label: "Total PNK", align: "right" },
             ];
           return [
             { key: "Address", label: "Address", align: "left" },
@@ -541,7 +578,24 @@
           sws["!cols"] = [{ wch: 44 }, { wch: 20 }, { wch: 20 }, { wch: 20 }];
           XLSX.utils.book_append_sheet(wb, sws, "Summary");
 
-          for (const label of tabList.slice(1)) {
+          const monthlyTotalRows = sortedMonths.map((label) => {
+            const { mainnet, gnosis } = monthData[label];
+            let m = 0,
+              g = 0;
+            for (const v of Object.values(mainnet)) m += v;
+            for (const v of Object.values(gnosis)) g += v;
+            return {
+              Month: label,
+              "Mainnet PNK": Math.round(m * 100) / 100,
+              "Gnosis PNK": Math.round(g * 100) / 100,
+              "Total PNK": Math.round((m + g) * 100) / 100,
+            };
+          });
+          const mts = XLSX.utils.json_to_sheet(monthlyTotalRows);
+          mts["!cols"] = [{ wch: 14 }, { wch: 18 }, { wch: 18 }, { wch: 18 }];
+          XLSX.utils.book_append_sheet(wb, mts, "Monthly Totals");
+
+          for (const label of sortedMonths) {
             const { mainnet, gnosis } = monthData[label];
             const allAddrs = new Set([...Object.keys(mainnet), ...Object.keys(gnosis)]);
             if (allAddrs.size === 0) continue;
@@ -634,7 +688,7 @@
                 )}
                 {phase === "done" && (
                   <span style={{ fontSize: 10, color: "#6c6c8a" }}>
-                    {Object.keys(grandTotals).length.toLocaleString()} addresses &middot; {tabList.length - 1} months
+                    {Object.keys(grandTotals).length.toLocaleString()} addresses &middot; {sortedMonths.length} months
                   </span>
                 )}
               </div>
@@ -776,7 +830,12 @@
 
                 {/* Table */}
                 <div className="table-wrap" style={{ flex: 1, overflow: "auto", padding: "16px 20px" }}>
-                  <SpreadsheetTable rows={currentRows} columns={currentColumns} />
+                  <SpreadsheetTable
+                    rows={currentRows}
+                    columns={currentColumns}
+                    noun={activeTab === "Monthly Totals" ? "month" : "address"}
+                    nounPlural={activeTab === "Monthly Totals" ? "months" : "addresses"}
+                  />
                 </div>
 
                 {/* Fetch errors */}

--- a/public/staking-rewards.html
+++ b/public/staking-rewards.html
@@ -137,6 +137,67 @@
         return n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
       }
 
+      // Round a PNK amount to 2 decimal places.
+      function round2(n) {
+        return Math.round(n * 100) / 100;
+      }
+
+      // Sort month labels newest-first, keeping the combined "2021-01 & 02" bucket last.
+      function compareMonths(a, b) {
+        if (a === "2021-01 & 02") return 1;
+        if (b === "2021-01 & 02") return -1;
+        return b.localeCompare(a);
+      }
+
+      // Build a { Month, Mainnet PNK, Gnosis PNK, Total PNK } row summing all wallets for a month.
+      function monthTotalRow(label, bucket) {
+        let m = 0,
+          g = 0;
+        for (const v of Object.values(bucket.mainnet)) m += v;
+        for (const v of Object.values(bucket.gnosis)) g += v;
+        return {
+          Month: label,
+          "Mainnet PNK": round2(m),
+          "Gnosis PNK": round2(g),
+          "Total PNK": round2(m + g),
+        };
+      }
+
+      // Build sorted per-wallet { Address, Mainnet PNK, Gnosis PNK, Total PNK } rows for one month.
+      function monthWalletRows(bucket) {
+        const addrs = new Set([...Object.keys(bucket.mainnet), ...Object.keys(bucket.gnosis)]);
+        return [...addrs]
+          .map((addr) => {
+            const m = bucket.mainnet[addr] || 0;
+            const g = bucket.gnosis[addr] || 0;
+            return {
+              Address: addr,
+              "Mainnet PNK": round2(m),
+              "Gnosis PNK": round2(g),
+              "Total PNK": round2(m + g),
+            };
+          })
+          .sort((a, b) => b["Total PNK"] - a["Total PNK"]);
+      }
+
+      // Build the 4-column spec shared by every tab: a left-aligned first column,
+      // the two right-aligned PNK columns, and a right-aligned final total column.
+      function pnkColumns(firstKey, lastKey) {
+        return [
+          { key: firstKey, label: firstKey, align: "left" },
+          { key: "Mainnet PNK", label: "Mainnet PNK", align: "right" },
+          { key: "Gnosis PNK", label: "Gnosis PNK", align: "right" },
+          { key: lastKey, label: lastKey, align: "right" },
+        ];
+      }
+
+      // Append a worksheet built from row objects, with the given column widths.
+      function addSheet(wb, name, rows, widths) {
+        const ws = XLSX.utils.json_to_sheet(rows);
+        ws["!cols"] = widths.map((wch) => ({ wch }));
+        XLSX.utils.book_append_sheet(wb, ws, name);
+      }
+
       // Spreadsheet-like table component
       const PAGE_SIZE = 100;
 
@@ -471,11 +532,7 @@
             setProgress((p) => ({ ...p, done: Math.min(i + CONCURRENCY, total) }));
           }
 
-          const sorted = Object.keys(md).sort((a, b) => {
-            if (a === "2021-01 & 02") return 1;
-            if (b === "2021-01 & 02") return -1;
-            return b.localeCompare(a);
-          });
+          const sorted = Object.keys(md).sort(compareMonths);
 
           setMonthData(md);
           setGrandTotals(gt);
@@ -488,11 +545,7 @@
         // Months sorted newest-first (matches the tab order)
         const sortedMonths = useMemo(() => {
           if (!monthData) return [];
-          return Object.keys(monthData).sort((a, b) => {
-            if (a === "2021-01 & 02") return 1;
-            if (b === "2021-01 & 02") return -1;
-            return b.localeCompare(a);
-          });
+          return Object.keys(monthData).sort(compareMonths);
         }, [monthData]);
 
         // Build rows for current tab
@@ -502,64 +555,22 @@
             return Object.entries(grandTotals)
               .map(([addr, t]) => ({
                 Address: addr,
-                "Mainnet PNK": Math.round(t.mainnet * 100) / 100,
-                "Gnosis PNK": Math.round(t.gnosis * 100) / 100,
-                "Grand Total": Math.round((t.mainnet + t.gnosis) * 100) / 100,
+                "Mainnet PNK": round2(t.mainnet),
+                "Gnosis PNK": round2(t.gnosis),
+                "Grand Total": round2(t.mainnet + t.gnosis),
               }))
               .sort((a, b) => b["Grand Total"] - a["Grand Total"]);
           }
           if (activeTab === "Monthly Totals") {
-            return sortedMonths.map((label) => {
-              const { mainnet, gnosis } = monthData[label];
-              let m = 0,
-                g = 0;
-              for (const v of Object.values(mainnet)) m += v;
-              for (const v of Object.values(gnosis)) g += v;
-              return {
-                Month: label,
-                "Mainnet PNK": Math.round(m * 100) / 100,
-                "Gnosis PNK": Math.round(g * 100) / 100,
-                "Total PNK": Math.round((m + g) * 100) / 100,
-              };
-            });
+            return sortedMonths.map((label) => monthTotalRow(label, monthData[label]));
           }
-          const { mainnet, gnosis } = monthData[activeTab] || { mainnet: {}, gnosis: {} };
-          const allAddrs = new Set([...Object.keys(mainnet), ...Object.keys(gnosis)]);
-          return [...allAddrs]
-            .map((addr) => {
-              const m = mainnet[addr] || 0;
-              const g = gnosis[addr] || 0;
-              return {
-                Address: addr,
-                "Mainnet PNK": Math.round(m * 100) / 100,
-                "Gnosis PNK": Math.round(g * 100) / 100,
-                "Total PNK": Math.round((m + g) * 100) / 100,
-              };
-            })
-            .sort((a, b) => (b["Total PNK"] || 0) - (a["Total PNK"] || 0));
+          return monthWalletRows(monthData[activeTab] || { mainnet: {}, gnosis: {} });
         }, [activeTab, grandTotals, monthData, sortedMonths]);
 
         const currentColumns = useMemo(() => {
-          if (activeTab === "Summary")
-            return [
-              { key: "Address", label: "Address", align: "left" },
-              { key: "Mainnet PNK", label: "Mainnet PNK", align: "right" },
-              { key: "Gnosis PNK", label: "Gnosis PNK", align: "right" },
-              { key: "Grand Total", label: "Grand Total", align: "right" },
-            ];
-          if (activeTab === "Monthly Totals")
-            return [
-              { key: "Month", label: "Month", align: "left" },
-              { key: "Mainnet PNK", label: "Mainnet PNK", align: "right" },
-              { key: "Gnosis PNK", label: "Gnosis PNK", align: "right" },
-              { key: "Total PNK", label: "Total PNK", align: "right" },
-            ];
-          return [
-            { key: "Address", label: "Address", align: "left" },
-            { key: "Mainnet PNK", label: "Mainnet PNK", align: "right" },
-            { key: "Gnosis PNK", label: "Gnosis PNK", align: "right" },
-            { key: "Total PNK", label: "Total PNK", align: "right" },
-          ];
+          if (activeTab === "Summary") return pnkColumns("Address", "Grand Total");
+          if (activeTab === "Monthly Totals") return pnkColumns("Month", "Total PNK");
+          return pnkColumns("Address", "Total PNK");
         }, [activeTab]);
 
         function downloadXLSX() {
@@ -569,51 +580,20 @@
           const summaryRows = Object.entries(grandTotals)
             .map(([addr, t]) => ({
               Address: addr,
-              "Total Mainnet PNK": Math.round(t.mainnet * 100) / 100,
-              "Total Gnosis PNK": Math.round(t.gnosis * 100) / 100,
-              "Grand Total PNK": Math.round((t.mainnet + t.gnosis) * 100) / 100,
+              "Total Mainnet PNK": round2(t.mainnet),
+              "Total Gnosis PNK": round2(t.gnosis),
+              "Grand Total PNK": round2(t.mainnet + t.gnosis),
             }))
             .sort((a, b) => b["Grand Total PNK"] - a["Grand Total PNK"]);
-          const sws = XLSX.utils.json_to_sheet(summaryRows);
-          sws["!cols"] = [{ wch: 44 }, { wch: 20 }, { wch: 20 }, { wch: 20 }];
-          XLSX.utils.book_append_sheet(wb, sws, "Summary");
+          addSheet(wb, "Summary", summaryRows, [44, 20, 20, 20]);
 
-          const monthlyTotalRows = sortedMonths.map((label) => {
-            const { mainnet, gnosis } = monthData[label];
-            let m = 0,
-              g = 0;
-            for (const v of Object.values(mainnet)) m += v;
-            for (const v of Object.values(gnosis)) g += v;
-            return {
-              Month: label,
-              "Mainnet PNK": Math.round(m * 100) / 100,
-              "Gnosis PNK": Math.round(g * 100) / 100,
-              "Total PNK": Math.round((m + g) * 100) / 100,
-            };
-          });
-          const mts = XLSX.utils.json_to_sheet(monthlyTotalRows);
-          mts["!cols"] = [{ wch: 14 }, { wch: 18 }, { wch: 18 }, { wch: 18 }];
-          XLSX.utils.book_append_sheet(wb, mts, "Monthly Totals");
+          const monthlyTotalRows = sortedMonths.map((label) => monthTotalRow(label, monthData[label]));
+          addSheet(wb, "Monthly Totals", monthlyTotalRows, [14, 18, 18, 18]);
 
           for (const label of sortedMonths) {
-            const { mainnet, gnosis } = monthData[label];
-            const allAddrs = new Set([...Object.keys(mainnet), ...Object.keys(gnosis)]);
-            if (allAddrs.size === 0) continue;
-            const rows = [...allAddrs]
-              .map((addr) => {
-                const m = mainnet[addr] || 0;
-                const g = gnosis[addr] || 0;
-                return {
-                  Address: addr,
-                  "Mainnet PNK": Math.round(m * 100) / 100,
-                  "Gnosis PNK": Math.round(g * 100) / 100,
-                  "Total PNK": Math.round((m + g) * 100) / 100,
-                };
-              })
-              .sort((a, b) => b["Total PNK"] - a["Total PNK"]);
-            const ws = XLSX.utils.json_to_sheet(rows);
-            ws["!cols"] = [{ wch: 44 }, { wch: 18 }, { wch: 18 }, { wch: 18 }];
-            XLSX.utils.book_append_sheet(wb, ws, label.slice(0, 31));
+            const rows = monthWalletRows(monthData[label]);
+            if (rows.length === 0) continue;
+            addSheet(wb, label.slice(0, 31), rows, [44, 18, 18, 18]);
           }
 
           const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces several utility functions to enhance the handling of PNK amounts and improves the `SpreadsheetTable` component to support dynamic noun labels. It also refactors the way monthly totals are calculated and displayed.

### Detailed summary
- Added `round2`, `compareMonths`, `monthTotalRow`, `monthWalletRows`, `pnkColumns`, and `addSheet` functions.
- Updated `SpreadsheetTable` to accept `noun` and `nounPlural` props.
- Refactored filtering and sorting logic in `SpreadsheetTable`.
- Improved month sorting and total calculations.
- Enhanced XLSX export functionality to include monthly totals.
- Adjusted displayed labels for address counts based on active tab.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **“Monthly Totals”** tab to show aggregated staking rewards by month
  * Extended **XLSX export** to include a **“Monthly Totals”** worksheet alongside existing per-month and overall summary exports
* **Improvements**
  * Updated table text and headers to adapt to the active tab and the currently displayed month set
  * Improved search/filtering to apply consistently across data views using the active table configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->