### PR TITLE
feat: add voting type tooltip to court information

### DIFF
--- a/src/components/court-cascader-modal.js
+++ b/src/components/court-cascader-modal.js
@@ -1,4 +1,4 @@
-import { Button, Cascader, Col, Modal, Row, Skeleton, Tooltip, Typography } from "antd";
+import { Button, Cascader, Col, Icon, Modal, Row, Skeleton, Tooltip, Typography } from "antd";
 import React, { useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import ReactMarkdown from "react-markdown";
@@ -151,6 +151,23 @@ const CourtCascaderModal = ({ onClick }) => {
                         tokenSymbol="PNK"
                       />
                       .
+                      {_court !== null && (
+                        <>
+                          {" | "}
+                          <Tooltip
+                            title={
+                              _court.hiddenVotes
+                                ? "Jurors in this court must commit their vote first and reveal it later."
+                                : "Jurors in this court cast their vote in a single step, visible to others."
+                            }
+                          >
+                            <StyledVoteTypeDisplay>
+                              <span>{_court.hiddenVotes ? "Hidden votes" : "Public votes"}</span>
+                              <StyledInfoIcon type="info-circle" theme="filled" />
+                            </StyledVoteTypeDisplay>
+                          </Tooltip>
+                        </>
+                      )}
                     </StyledMinStakeDisplay>
                   </Typography.Title>
                   <ReactMarkdown source={option.description} />
@@ -424,4 +441,17 @@ const StyledMinStakeDisplay = styled.div`
   font-weight: 400;
   font-size: 12px;
   margin: 3px 0 20px 0;
+`;
+
+const StyledVoteTypeDisplay = styled.span`
+  cursor: help;
+
+  span {
+    border-bottom: 1px dotted currentColor;
+  }
+`;
+
+const StyledInfoIcon = styled(Icon)`
+  margin-left: 4px;
+  vertical-align: middle;
 `;


### PR DESCRIPTION
Resolves #589.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a tooltip feature to display information about the voting type in the `CourtCascaderModal`. It enhances user experience by providing clarity on whether votes are hidden or public.

### Detailed summary
- Added a conditional rendering block for `_court` to display a tooltip.
- The tooltip informs users about hidden vs. public votes.
- Introduced `StyledVoteTypeDisplay` for styling the vote type display.
- Added `StyledInfoIcon` for an info icon next to the vote type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive informational icon in the Min Stake display area. When a court is selected, the icon displays a tooltip describing the court's voting mechanism, indicating whether the selected court uses hidden votes (commit-then-reveal voting process) or public votes (single-step visible voting). Enhanced visual feedback on hover improves user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->