### PR TITLE
fix incorrect handling of onchain resolution of "ipfs://" uls

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "prestart": "run-s build:theme",
     "start": "cross-env BROWSER=none react-app-rewired start",
+    "test": "react-app-rewired test --watchAll=false",
     "prebuild": "run-s build:theme",
     "build": "react-app-rewired build",
     "build:analyze": "source-map-explorer build/static/js/main.*",

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -27,7 +27,7 @@ const getHttpUri = (uri) => {
       if (uri.substr(0, 5) === "/ipfs" || uri.substr(0, 5) === "ipfs/") {
         if (uri.substr(0, 1) === "/") uri = uri.substr(1, uri.length - 1);
         uri = `https://cdn.kleros.link/${uri}`;
-      } else if (uri.substr(0, 6) === "ipfs:/") uri = `https://cdn.kleros.link/${uri.split(":/").pop()}`;
+      } else if (uri.substr(0, 6) === "ipfs:/") uri = `https://cdn.kleros.link/ipfs/${uri.split(":/").pop()}`;
       else throw new Error(`Unrecognized protocol ${protocol}`);
       break;
     default:

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import useSWR from "swr";
 import arbitrableWhitelist from "../temp/arbitrable-whitelist";
 import { displaySubgraph } from "./subgraph";
+import { normalizeIpfsUri } from "../utils/ipfs-normalizer";
 
 const getURIProtocol = (uri) => {
   const uriParts = uri.replace(":", "").split("/");
@@ -23,12 +24,8 @@ const getHttpUri = (uri) => {
       else throw new Error(`Unrecognized protocol ${protocol}`);
       break;
     case "ipfs":
-      uri = uri.replace("://", ":/");
-      if (uri.substr(0, 5) === "/ipfs" || uri.substr(0, 5) === "ipfs/") {
-        if (uri.substr(0, 1) === "/") uri = uri.substr(1, uri.length - 1);
-        uri = `https://cdn.kleros.link/${uri}`;
-      } else if (uri.substr(0, 6) === "ipfs:/") uri = `https://cdn.kleros.link/ipfs/${uri.split(":/").pop()}`;
-      else throw new Error(`Unrecognized protocol ${protocol}`);
+      uri = normalizeIpfsUri(uri);
+      if (!uri.startsWith("https://")) throw new Error(`Unrecognized protocol ${protocol}`);
       break;
     default:
       throw new Error(`Unrecognized protocol ${protocol}`);

--- a/src/components/attachment.js
+++ b/src/components/attachment.js
@@ -39,6 +39,12 @@ const DisabledAttachment = styled.span`
 
 const isPDF = (extension) => extension.toLowerCase() === ".pdf";
 
+const getSafeNavigationUrl = (uri) => {
+  const normalizedUri = normalizeIpfsUri(uri);
+
+  return isSafeNavigationUrl(normalizedUri) ? normalizedUri : null;
+};
+
 const Attachment = ({ URI, description, extension: _extension, previewURI, title }) => {
   let extension;
   if (!_extension && URI) extension = `.${URI.split(".").pop()}`;
@@ -52,16 +58,18 @@ const Attachment = ({ URI, description, extension: _extension, previewURI, title
   else Component = Link;
   Component = <Component className="primary-purple-fill theme-fill" />;
 
-  const href = normalizeIpfsUri(URI);
-  const previewHref = normalizeIpfsUri(previewURI);
+  const navigationUrls = {
+    attachment: getSafeNavigationUrl(URI),
+    preview: getSafeNavigationUrl(previewURI),
+  };
 
   // Unsafe attachment URL still indicate that a file was attached,
   // but render it as a disabled, non-clickable icon with an explanation.
-  if (!isSafeNavigationUrl(href)) {
+  if (!navigationUrls.attachment) {
     return (
       <Tooltip
         overlayStyle={{ wordBreak: "break-all" }}
-        title={`This attachment link was flagged as unsafe and has been disabled: "${href}"`}
+        title={`This attachment link was flagged as unsafe and has been disabled: "${normalizeIpfsUri(URI)}"`}
       >
         <DisabledAttachment>{Component}</DisabledAttachment>
       </Tooltip>
@@ -69,7 +77,7 @@ const Attachment = ({ URI, description, extension: _extension, previewURI, title
   }
 
   const LinkedComponent = (
-    <a href={href} rel="noopener noreferrer" target="_blank">
+    <a href={navigationUrls.attachment} rel="noopener noreferrer" target="_blank">
       {Component}
     </a>
   );
@@ -84,11 +92,11 @@ const Attachment = ({ URI, description, extension: _extension, previewURI, title
       arrowPointAtCenter
       className=""
       content={
-        previewURI ? (
+        navigationUrls.preview ? (
           <>
             {description}
             <Divider dashed />
-            <StyledIFrame sandbox="" frameBorder="0" src={previewHref} title="Attachment Preview" />
+            <StyledIFrame sandbox="" frameBorder="0" src={navigationUrls.preview} title="Attachment Preview" />
           </>
         ) : (
           description

--- a/src/components/attachment.js
+++ b/src/components/attachment.js
@@ -10,6 +10,7 @@ import { ReactComponent as Image } from "../assets/images/image.svg";
 import { ReactComponent as Link } from "../assets/images/link.svg";
 import { ReactComponent as PDF } from "../assets/images/pdf.svg";
 import { ReactComponent as Video } from "../assets/images/video.svg";
+import { normalizeIpfsUri } from "../utils/ipfs-normalizer";
 import { isSafeNavigationUrl } from "../utils/urlValidation";
 
 const StyledPopover = styled(({ className, ...rest }) => (
@@ -51,7 +52,8 @@ const Attachment = ({ URI, description, extension: _extension, previewURI, title
   else Component = Link;
   Component = <Component className="primary-purple-fill theme-fill" />;
 
-  const href = URI.replace(/^\/ipfs\//, "https://cdn.kleros.link/ipfs/");
+  const href = normalizeIpfsUri(URI);
+  const previewHref = normalizeIpfsUri(previewURI);
 
   // Unsafe attachment URL still indicate that a file was attached,
   // but render it as a disabled, non-clickable icon with an explanation.
@@ -86,7 +88,7 @@ const Attachment = ({ URI, description, extension: _extension, previewURI, title
           <>
             {description}
             <Divider dashed />
-            <StyledIFrame sandbox="" frameBorder="0" src={previewURI} title="Attachment Preview" />
+            <StyledIFrame sandbox="" frameBorder="0" src={previewHref} title="Attachment Preview" />
           </>
         ) : (
           description

--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -29,6 +29,7 @@ import { getReadOnlyRpcUrl } from "../bootstrap/web3";
 import useGetDraws from "../hooks/use-get-draws";
 import arbitrableWhitelist from "../temp/arbitrable-whitelist";
 import { getAnswerString, RTA_LABEL } from "../temp/answer-string";
+import { normalizeIpfsUri } from "../utils/ipfs-normalizer";
 import { isSafeNavigationUrl } from "../utils/urlValidation";
 
 const { useDrizzle, useDrizzleState } = drizzleReactHooks;
@@ -494,7 +495,6 @@ export default function CaseDetailsCard({ ID }) {
   }, [dispute?.arbitrated, arbitrableChainID, metaEvidence]);
 
   const evidenceDisplayInterfaceURL = useMemo(() => {
-    const normalizeIPFSUri = (uri) => uri.replace(/^\/ipfs\//, "https://cdn.kleros.link/ipfs/");
     if (metaEvidence?.evidenceDisplayInterfaceURI) {
       // hack to allow displaying old t2cr disputes, since old endpoint was lost
       const evidenceDisplayInterfaceURI =
@@ -504,7 +504,7 @@ export default function CaseDetailsCard({ ID }) {
 
       const { _v = "0" } = metaEvidence;
 
-      let url = normalizeIPFSUri(evidenceDisplayInterfaceURI);
+      let url = normalizeIpfsUri(evidenceDisplayInterfaceURI);
       if (!isSafeNavigationUrl(url)) return null;
 
       const injectedParams = {
@@ -528,6 +528,9 @@ export default function CaseDetailsCard({ ID }) {
       return url;
     }
   }, [metaEvidence, ID, dispute, chainId, KlerosLiquid.address, arbitratorChainID, arbitrableChainID]);
+  const arbitrableInterfaceURL = useMemo(() => normalizeIpfsUri(metaEvidence?.arbitrableInterfaceURI), [
+    metaEvidence?.arbitrableInterfaceURI,
+  ]);
 
   return (
     <>
@@ -705,9 +708,9 @@ export default function CaseDetailsCard({ ID }) {
                       />
                     </StyledIframeContainer>
                   )}
-                  {metaEvidence.arbitrableInterfaceURI && isSafeNavigationUrl(metaEvidence.arbitrableInterfaceURI) && (
+                  {arbitrableInterfaceURL && isSafeNavigationUrl(arbitrableInterfaceURL) && (
                     <ArbitrableInterfaceDiv>
-                      <a href={metaEvidence.arbitrableInterfaceURI} target="_blank" rel="noopener noreferrer">
+                      <a href={arbitrableInterfaceURL} target="_blank" rel="noopener noreferrer">
                         <Icon type="double-right" style={{ marginRight: "5px" }} />
                         Go to the Arbitrable Application
                       </a>

--- a/src/utils/ipfs-normalizer.js
+++ b/src/utils/ipfs-normalizer.js
@@ -1,0 +1,26 @@
+const CDN_URL = "https://cdn.kleros.link";
+
+const toIpfsPath = (uri) => {
+  if (uri.startsWith("/ipfs/")) return uri;
+  if (uri.startsWith("ipfs/")) return `/ipfs/${uri.slice("ipfs/".length)}`;
+
+  return `/ipfs/${uri.replace(/^\/+/, "")}`;
+};
+
+export const normalizeIpfsUri = (uri) => {
+  if (!uri || typeof uri !== "string") return uri;
+
+  uri = uri.trim();
+
+  if (uri.startsWith("http://") || uri.startsWith("https://")) return uri;
+
+  if (uri.startsWith("ipfs:")) {
+    return `${CDN_URL}${toIpfsPath(uri.replace(/^ipfs:(\/\/?)/, ""))}`;
+  }
+
+  if (uri.startsWith("/ipfs/") || uri.startsWith("ipfs/")) {
+    return `${CDN_URL}${toIpfsPath(uri)}`;
+  }
+
+  return uri;
+};

--- a/src/utils/ipfs.test.js
+++ b/src/utils/ipfs.test.js
@@ -1,4 +1,5 @@
 import { normalizeIpfsUri } from "./ipfs-normalizer";
+import { isSafeNavigationUrl } from "./urlValidation";
 
 describe("normalizeIpfsUri", () => {
   it.each([
@@ -29,5 +30,19 @@ describe("normalizeIpfsUri", () => {
     expect(normalizeIpfsUri("data.json")).toBe("data.json");
     expect(normalizeIpfsUri(null)).toBe(null);
     expect(normalizeIpfsUri(undefined)).toBe(undefined);
+  });
+
+  it("does not preserve executable schemes when normalizing IPFS URIs", () => {
+    const normalizedUri = normalizeIpfsUri("ipfs://javascript:alert(1)");
+
+    expect(normalizedUri).toBe("https://cdn.kleros.link/ipfs/javascript:alert(1)");
+    expect(new URL(normalizedUri).protocol).toBe("https:");
+  });
+
+  it("keeps non-IPFS executable schemes unsafe", () => {
+    const normalizedUri = normalizeIpfsUri("javascript:alert(1)");
+
+    expect(normalizedUri).toBe("javascript:alert(1)");
+    expect(isSafeNavigationUrl(normalizedUri)).toBe(false);
   });
 });

--- a/src/utils/ipfs.test.js
+++ b/src/utils/ipfs.test.js
@@ -1,0 +1,33 @@
+import { normalizeIpfsUri } from "./ipfs-normalizer";
+
+describe("normalizeIpfsUri", () => {
+  it.each([
+    ["ipfs://bafkreigi53smvtvoi2s5zh3wd5ztu7pzl4lao5v4y7xihd3bjrpwtuyk2a"],
+    ["ipfs:/bafkreigi53smvtvoi2s5zh3wd5ztu7pzl4lao5v4y7xihd3bjrpwtuyk2a"],
+    ["/ipfs/bafkreigi53smvtvoi2s5zh3wd5ztu7pzl4lao5v4y7xihd3bjrpwtuyk2a"],
+    ["ipfs/bafkreigi53smvtvoi2s5zh3wd5ztu7pzl4lao5v4y7xihd3bjrpwtuyk2a"],
+  ])("normalizes %s to the Kleros CDN IPFS path", (uri) => {
+    expect(normalizeIpfsUri(uri)).toBe(
+      "https://cdn.kleros.link/ipfs/bafkreigi53smvtvoi2s5zh3wd5ztu7pzl4lao5v4y7xihd3bjrpwtuyk2a"
+    );
+  });
+
+  it("normalizes IPFS URIs with nested paths", () => {
+    expect(normalizeIpfsUri("ipfs://QmYs17mAJTaQwYeXNTb6n4idoQXmRcAjREeUdjJShNSeKh/index.html")).toBe(
+      "https://cdn.kleros.link/ipfs/QmYs17mAJTaQwYeXNTb6n4idoQXmRcAjREeUdjJShNSeKh/index.html"
+    );
+  });
+
+  it("leaves absolute HTTP URLs unchanged", () => {
+    const uri = "https://cdn.kleros.link/ipfs/bafkreigi53smvtvoi2s5zh3wd5ztu7pzl4lao5v4y7xihd3bjrpwtuyk2a";
+
+    expect(normalizeIpfsUri(uri)).toBe(uri);
+    expect(normalizeIpfsUri("http://example.com/file.json")).toBe("http://example.com/file.json");
+  });
+
+  it("leaves non-IPFS values unchanged", () => {
+    expect(normalizeIpfsUri("data.json")).toBe("data.json");
+    expect(normalizeIpfsUri(null)).toBe(null);
+    expect(normalizeIpfsUri(undefined)).toBe(undefined);
+  });
+});


### PR DESCRIPTION
This fixes metaevidence URLs that are stored as ipfs://... so they resolve through Kleros CDN as https://cdn.kleros.link/ipfs/... instead of dropping the /ipfs/ segment.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily introduces a new utility function, `normalizeIpfsUri`, for standardizing IPFS URIs and updates components to utilize this function for improved URI handling and safety checks.

### Detailed summary
- Added `normalizeIpfsUri` function in `src/utils/ipfs-normalizer.js`.
- Updated `getHttpUri` to use `normalizeIpfsUri` in `src/bootstrap/dataloader.js`.
- Introduced tests for `normalizeIpfsUri` in `src/utils/ipfs.test.js`.
- Refactored `CaseDetailsCard` to replace inline normalization with `normalizeIpfsUri`.
- Updated `Attachment` component to use `normalizeIpfsUri` for safer URL handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPFS URI normalization so CDN links consistently include the `/ipfs/` segment, including `ipfs:/...` inputs.
  * Updated attachment and “Go to the Arbitrable Application” navigation to use the same normalized URLs and only enable links when they pass safety checks.

* **New Features**
  * Added a shared IPFS URI normalizer used across the app.

* **Tests**
  * Expanded coverage for IPFS URI variants, including scheme-handling and safety expectations.

* **Chores**
  * Updated the test script to run once (no watch mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->