### PR TITLE
fix: centralize IPFS URI handling and improve logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "prestart": "run-s build:theme",
     "start": "cross-env BROWSER=none react-app-rewired start",
+    "test": "react-app-rewired test --watchAll=false",
     "prebuild": "run-s build:theme",
     "build": "react-app-rewired build",
     "build:analyze": "source-map-explorer build/static/js/main.*",
@@ -104,7 +105,8 @@
     "web3": "1.5.2"
   },
   "resolutions": {
-    "html-to-text": "^7.0.0"
+    "html-to-text": "^7.0.0",
+    "graceful-fs": "^4.2.11"
   },
   "volta": {
     "node": "16.20.2",

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import useSWR from "swr";
 import arbitrableWhitelist from "../temp/arbitrable-whitelist";
 import { displaySubgraph } from "./subgraph";
+import { isContentAddressed, toHttpUrl } from "../utils/ipfs";
 
 const getURIProtocol = (uri) => {
   const uriParts = uri.replace(":", "").split("/");
@@ -23,12 +24,7 @@ const getHttpUri = (uri) => {
       else throw new Error(`Unrecognized protocol ${protocol}`);
       break;
     case "ipfs":
-      uri = uri.replace("://", ":/");
-      if (uri.substr(0, 5) === "/ipfs" || uri.substr(0, 5) === "ipfs/") {
-        if (uri.substr(0, 1) === "/") uri = uri.substr(1, uri.length - 1);
-        uri = `https://cdn.kleros.link/${uri}`;
-      } else if (uri.substr(0, 6) === "ipfs:/") uri = `https://cdn.kleros.link/${uri.split(":/").pop()}`;
-      else throw new Error(`Unrecognized protocol ${protocol}`);
+      uri = toHttpUrl(uri);
       break;
     default:
       throw new Error(`Unrecognized protocol ${protocol}`);
@@ -129,6 +125,7 @@ const funcs = {
 
         const uri = metaEvidenceUriData.data?.metaEvidenceUri;
         if (!uri) throw new Error(`No MetaEvidence log for disputeId ${disputeId} on chainID ${chainID}`);
+        if (!isContentAddressed(uri)) break;
 
         let metaEvidenceJSON = (await axios.get(getHttpUri(uri))).data;
 
@@ -149,6 +146,8 @@ const funcs = {
           metaEvidenceJSON.rulingOptions.type = "single-select";
 
         if (metaEvidenceJSON.dynamicScriptURI) {
+          if (!isContentAddressed(metaEvidenceJSON.dynamicScriptURI)) break;
+
           const scriptURI =
             chainID === 1 && disputeId === "1621"
               ? getHttpUri("/ipfs/Qmf1k727vP7qZv21MDB8vwL6tfVEKPCUQAiw8CTfHStkjf")
@@ -216,10 +215,11 @@ const funcs = {
       console.error("No URI provided");
       return;
     }
-    const prefix = URI.startsWith("/ipfs/") ? "" : "/ipfs/";
-    const policyURL = `https://cdn.kleros.link${prefix}${URI}`;
+    const policyURL = toHttpUrl(URI);
 
     try {
+      if (!isContentAddressed(URI)) throw new Error(`Policy URI is not content-addressed: ${URI}`);
+
       const res = await axios.get(policyURL);
 
       if (res.status !== 200)
@@ -311,6 +311,9 @@ const evidenceFetcher = async ([subgraph, disputeId]) => {
     await Promise.all(
       evidence.map(async (evidenceItem) => {
         try {
+          if (!isContentAddressed(evidenceItem.URI))
+            throw new Error(`Evidence URI is not content-addressed: ${evidenceItem.URI}`);
+
           const uri = getHttpUri(evidenceItem.URI);
           try {
             const fileRes = await axios.get(uri);

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -13,24 +13,17 @@ const getURIProtocol = (uri) => {
 };
 
 const getHttpUri = (uri) => {
+  if (isContentAddressed(uri)) return toHttpUrl(uri);
+
   const protocol = getURIProtocol(uri);
   switch (protocol) {
     case "http":
     case "https":
     case "ipns":
-      break;
-    case "fs":
-      if (uri.includes("/ipfs/")) uri = toHttpUrl(uri);
-      else throw new Error(`Unrecognized protocol ${protocol}`);
-      break;
-    case "ipfs":
-      uri = toHttpUrl(uri);
-      break;
+      return uri;
     default:
       throw new Error(`Unrecognized protocol ${protocol}`);
   }
-
-  return uri;
 };
 
 const fetchDataFromScript = async (scriptString, scriptParameters) => {

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -20,7 +20,7 @@ const getHttpUri = (uri) => {
     case "ipns":
       break;
     case "fs":
-      if (uri.includes("/ipfs/")) uri = uri.split(":/").pop();
+      if (uri.includes("/ipfs/")) uri = toHttpUrl(uri);
       else throw new Error(`Unrecognized protocol ${protocol}`);
       break;
     case "ipfs":
@@ -208,6 +208,7 @@ const funcs = {
       description:
         "In case you have an AdBlock enabled, please disable it and refresh the page. It may be preventing the correct working of the page. If that's not the case, the data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.",
       title: "Invalid or tampered case data, refuse to arbitrate.",
+      rulingOptions: { type: "single-select", titles: [] },
     };
   },
   async loadPolicy(URI) {

--- a/src/components/attachment.js
+++ b/src/components/attachment.js
@@ -11,6 +11,7 @@ import { ReactComponent as Link } from "../assets/images/link.svg";
 import { ReactComponent as PDF } from "../assets/images/pdf.svg";
 import { ReactComponent as Video } from "../assets/images/video.svg";
 import { isSafeNavigationUrl } from "../utils/urlValidation";
+import { isContentAddressed, toHttpUrl } from "../utils/ipfs";
 
 const StyledPopover = styled(({ className, ...rest }) => (
   <Popover className={className} overlayClassName={className} {...rest} />
@@ -51,11 +52,11 @@ const Attachment = ({ URI, description, extension: _extension, previewURI, title
   else Component = Link;
   Component = <Component className="primary-purple-fill theme-fill" />;
 
-  const href = URI.replace(/^\/ipfs\//, "https://cdn.kleros.link/ipfs/");
+  const href = toHttpUrl(URI);
 
-  // Unsafe attachment URL still indicate that a file was attached,
-  // but render it as a disabled, non-clickable icon with an explanation.
-  if (!isSafeNavigationUrl(href)) {
+  //A rejected attachment still indicates that a file was attached,
+  //but renders as a disabled, non-clickable icon with an explanation.
+  if (!isContentAddressed(URI) || !isSafeNavigationUrl(href)) {
     return (
       <Tooltip
         overlayStyle={{ wordBreak: "break-all" }}

--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -30,6 +30,7 @@ import useGetDraws from "../hooks/use-get-draws";
 import arbitrableWhitelist from "../temp/arbitrable-whitelist";
 import { getAnswerString, RTA_LABEL } from "../temp/answer-string";
 import { isSafeNavigationUrl } from "../utils/urlValidation";
+import { toHttpUrl } from "../utils/ipfs";
 
 const { useDrizzle, useDrizzleState } = drizzleReactHooks;
 const { toBN, soliditySha3 } = Web3.utils;
@@ -494,7 +495,6 @@ export default function CaseDetailsCard({ ID }) {
   }, [dispute?.arbitrated, arbitrableChainID, metaEvidence]);
 
   const evidenceDisplayInterfaceURL = useMemo(() => {
-    const normalizeIPFSUri = (uri) => uri.replace(/^\/ipfs\//, "https://cdn.kleros.link/ipfs/");
     if (metaEvidence?.evidenceDisplayInterfaceURI) {
       // hack to allow displaying old t2cr disputes, since old endpoint was lost
       const evidenceDisplayInterfaceURI =
@@ -504,7 +504,7 @@ export default function CaseDetailsCard({ ID }) {
 
       const { _v = "0" } = metaEvidence;
 
-      let url = normalizeIPFSUri(evidenceDisplayInterfaceURI);
+      let url = toHttpUrl(evidenceDisplayInterfaceURI);
       if (!isSafeNavigationUrl(url)) return null;
 
       const injectedParams = {
@@ -528,6 +528,12 @@ export default function CaseDetailsCard({ ID }) {
       return url;
     }
   }, [metaEvidence, ID, dispute, chainId, KlerosLiquid.address, arbitratorChainID, arbitrableChainID]);
+
+  const arbitrableInterfaceURL = useMemo(() => {
+    if (!metaEvidence?.arbitrableInterfaceURI) return null;
+    const url = toHttpUrl(metaEvidence.arbitrableInterfaceURI);
+    return isSafeNavigationUrl(url) ? url : null;
+  }, [metaEvidence]);
 
   return (
     <>
@@ -705,9 +711,9 @@ export default function CaseDetailsCard({ ID }) {
                       />
                     </StyledIframeContainer>
                   )}
-                  {metaEvidence.arbitrableInterfaceURI && isSafeNavigationUrl(metaEvidence.arbitrableInterfaceURI) && (
+                  {arbitrableInterfaceURL && (
                     <ArbitrableInterfaceDiv>
-                      <a href={metaEvidence.arbitrableInterfaceURI} target="_blank" rel="noopener noreferrer">
+                      <a href={arbitrableInterfaceURL} target="_blank" rel="noopener noreferrer">
                         <Icon type="double-right" style={{ marginRight: "5px" }} />
                         Go to the Arbitrable Application
                       </a>

--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -10,6 +10,7 @@ import { ReactComponent as RightArrow } from "../assets/images/right-arrow.svg";
 import useChainId from "../hooks/use-chain-id";
 import ETHAmount from "./eth-amount";
 import { klerosboardSubgraph } from "../bootstrap/subgraph";
+import { IPFS_GATEWAY } from "../utils/ipfs";
 
 const StyledModal = styled(Modal)`
   max-width: calc(100vw - 32px);
@@ -82,8 +83,6 @@ const StyledHr = styled.hr`
   border: 1px solid ${({ theme }) => theme.dividerColor};
   margin-bottom: 32px;
 `;
-
-const ipfsEndpoint = "https://cdn.kleros.link";
 
 const chainIdToParams = {
   1: {
@@ -267,7 +266,7 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
     const snapshots = airdropParams?.snapshots ?? [];
 
     for (var month = 0; month < snapshots.length; month++) {
-      responses[month] = fetch(`${ipfsEndpoint}/ipfs/${snapshots[month]}`);
+      responses[month] = fetch(`${IPFS_GATEWAY}/ipfs/${snapshots[month]}`);
     }
 
     const results = Promise.all(

--- a/src/helpers/rewards.js
+++ b/src/helpers/rewards.js
@@ -3,6 +3,7 @@ import PNKAbi from "../assets/contracts/pinakion.json";
 import Web3 from "web3";
 import { klerosboardSubgraph } from "../bootstrap/subgraph";
 import { getReadOnlyRpcUrl } from "../bootstrap/web3";
+import { IPFS_GATEWAY } from "../utils/ipfs";
 
 const CLAIM_MODAL_URL = "https://raw.githubusercontent.com/kleros/court/master/src/components/claim-modal.js";
 
@@ -52,7 +53,7 @@ async function getLatestSnapshotUrls() {
   );
   let matches = Array.from(claimModalCode.matchAll(reg));
   let urls = matches.map((r) => ({
-    url: `https://cdn.kleros.link/ipfs/${r.groups.cid}/${r.groups.filename}.json`,
+    url: `${IPFS_GATEWAY}/ipfs/${r.groups.cid}/${r.groups.filename}.json`,
     isGnosis: r.groups.filename.startsWith("xdai-"),
   }));
   if (urls.length === 0) {
@@ -64,7 +65,7 @@ async function getLatestSnapshotUrls() {
     );
     matches = Array.from(claimModalCode.matchAll(reg));
     urls = matches.map((r) => ({
-      url: `https://cdn.kleros.link/ipfs/${r.groups.cid}/${r.groups.filename}.json`,
+      url: `${IPFS_GATEWAY}/ipfs/${r.groups.cid}/${r.groups.filename}.json`,
       isGnosis: r.groups.filename.startsWith("xdai-"),
     }));
   }

--- a/src/utils/ipfs.js
+++ b/src/utils/ipfs.js
@@ -5,7 +5,7 @@ export const IPFS_GATEWAY = "https://cdn.kleros.link";
 export const toHttpUrl = (uri) => {
   if (typeof uri !== "string" || uri === "") return uri;
   if (/^https?:\/\//.test(uri)) return uri;
-  const path = uri.replace(/^ipfs:\/*/, "").replace(/^\/?(?:ipfs\/)?/, "");
+  const path = uri.replace(/^(?:ipfs:|fs:)\/*/, "").replace(/^\/?(?:ipfs\/)?/, "");
   return `${IPFS_GATEWAY}/ipfs/${path}`;
 };
 

--- a/src/utils/ipfs.js
+++ b/src/utils/ipfs.js
@@ -1,0 +1,13 @@
+export const IPFS_GATEWAY = "https://cdn.kleros.link";
+
+//Resolves a URI to an HTTP URL.
+//IPFS URIs in any of their common forms resolve to the Kleros gateway. Absolute http(s) URLs are returned unchanged.
+export const toHttpUrl = (uri) => {
+  if (typeof uri !== "string" || uri === "") return uri;
+  if (/^https?:\/\//.test(uri)) return uri;
+  const path = uri.replace(/^ipfs:\/*/, "").replace(/^\/?(?:ipfs\/)?/, "");
+  return `${IPFS_GATEWAY}/ipfs/${path}`;
+};
+
+//Evidence type URIs must be content-addressed.
+export const isContentAddressed = (uri) => typeof uri === "string" && /^(\/?ipfs\/|ipfs:|fs:\/*ipfs\/)/.test(uri);

--- a/src/utils/ipfs.js
+++ b/src/utils/ipfs.js
@@ -1,16 +1,22 @@
 export const IPFS_GATEWAY = "https://cdn.kleros.link";
 
+//CID shape check for CIDv0 and CIDv1 in base32 (the standard's default encoding).
+const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{50,})([/?#]|$)/;
+
+//Strips the common IPFS URI prefixes, leaving only the CID or CID/path.
+const toIpfsPath = (uri) =>
+  uri
+    .trim()
+    .replace(/^(?:ipfs:|fs:)\/*/, "")
+    .replace(/^\/?(?:ipfs\/)?/, "");
+
 //Resolves a URI to an HTTP URL.
 //IPFS URIs in any of their common forms resolve to the Kleros gateway. Absolute http(s) URLs are returned unchanged.
 export const toHttpUrl = (uri) => {
-  if (typeof uri !== "string" || uri === "") return undefined;
-  if (/^https?:\/\//.test(uri)) return uri;
-  const path = uri.replace(/^(?:ipfs:|fs:)\/*/, "").replace(/^\/?(?:ipfs\/)?/, "");
-  return `${IPFS_GATEWAY}/ipfs/${path}`;
+  if (typeof uri !== "string" || uri.trim() === "") return undefined;
+  if (/^https?:\/\//.test(uri.trim())) return uri.trim();
+  return `${IPFS_GATEWAY}/ipfs/${toIpfsPath(uri)}`;
 };
 
 //Evidence type URIs must be content-addressed.
-//Also accepts bare hashes: CIDv0 and CIDv1 in base32 (the standard's default).
-export const isContentAddressed = (uri) =>
-  typeof uri === "string" &&
-  (/^(\/?ipfs\/|ipfs:|fs:\/*ipfs\/)/.test(uri) || /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{50,})([/?#]|$)/.test(uri));
+export const isContentAddressed = (uri) => typeof uri === "string" && CID_REGEX.test(toIpfsPath(uri));

--- a/src/utils/ipfs.js
+++ b/src/utils/ipfs.js
@@ -3,11 +3,14 @@ export const IPFS_GATEWAY = "https://cdn.kleros.link";
 //Resolves a URI to an HTTP URL.
 //IPFS URIs in any of their common forms resolve to the Kleros gateway. Absolute http(s) URLs are returned unchanged.
 export const toHttpUrl = (uri) => {
-  if (typeof uri !== "string" || uri === "") return uri;
+  if (typeof uri !== "string" || uri === "") return undefined;
   if (/^https?:\/\//.test(uri)) return uri;
   const path = uri.replace(/^(?:ipfs:|fs:)\/*/, "").replace(/^\/?(?:ipfs\/)?/, "");
   return `${IPFS_GATEWAY}/ipfs/${path}`;
 };
 
 //Evidence type URIs must be content-addressed.
-export const isContentAddressed = (uri) => typeof uri === "string" && /^(\/?ipfs\/|ipfs:|fs:\/*ipfs\/)/.test(uri);
+//Also accepts bare hashes: CIDv0 and CIDv1 in base32 (the standard's default).
+export const isContentAddressed = (uri) =>
+  typeof uri === "string" &&
+  (/^(\/?ipfs\/|ipfs:|fs:\/*ipfs\/)/.test(uri) || /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{50,})([/?#]|$)/.test(uri));

--- a/src/utils/ipfs.test.js
+++ b/src/utils/ipfs.test.js
@@ -35,9 +35,15 @@ describe("toHttpUrl", () => {
 
   it("returns undefined for empty or non-string input", () => {
     expect(toHttpUrl("")).toBeUndefined();
+    expect(toHttpUrl("   ")).toBeUndefined();
     expect(toHttpUrl(null)).toBeUndefined();
     expect(toHttpUrl(undefined)).toBeUndefined();
     expect(toHttpUrl(42)).toBeUndefined();
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(toHttpUrl(` /ipfs/${CID_V0} `)).toBe(GATEWAY_URL);
+    expect(toHttpUrl(" https://curate.kleros.io ")).toBe("https://curate.kleros.io");
   });
 });
 
@@ -68,6 +74,13 @@ describe("isContentAddressed", () => {
     expect(isContentAddressed(`${CID_V0}X`)).toBe(false);
     expect(isContentAddressed("whatever")).toBe(false);
     expect(isContentAddressed("some random text")).toBe(false);
+  });
+
+  it("rejects accepted prefixes that are not followed by a CID", () => {
+    expect(isContentAddressed("/ipfs/whatever")).toBe(false);
+    expect(isContentAddressed("ipfs:whatever")).toBe(false);
+    expect(isContentAddressed("ipfs::whatever")).toBe(false);
+    expect(isContentAddressed("fs:/ipfs/whatever")).toBe(false);
   });
 
   it("rejects empty or non-string input", () => {

--- a/src/utils/ipfs.test.js
+++ b/src/utils/ipfs.test.js
@@ -1,0 +1,78 @@
+import { IPFS_GATEWAY, isContentAddressed, toHttpUrl } from "./ipfs";
+
+//Mainnet General Court policy
+const CID_V0 = "Qmd1TMEbtic3TSonu5dfqa5k3aSrjxRGY8oJH3ruGgazRB";
+
+//IPFS docs example
+const CID_V1 = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+
+const GATEWAY_URL = `${IPFS_GATEWAY}/ipfs/${CID_V0}`;
+
+describe("toHttpUrl", () => {
+  it("resolves all common IPFS URI forms to the gateway", () => {
+    expect(toHttpUrl(`/ipfs/${CID_V0}`)).toBe(GATEWAY_URL);
+    expect(toHttpUrl(`ipfs/${CID_V0}`)).toBe(GATEWAY_URL);
+    expect(toHttpUrl(`ipfs://${CID_V0}`)).toBe(GATEWAY_URL);
+    expect(toHttpUrl(`ipfs:${CID_V0}`)).toBe(GATEWAY_URL);
+    expect(toHttpUrl(`ipfs://ipfs/${CID_V0}`)).toBe(GATEWAY_URL);
+  });
+
+  it("resolves legacy fs: forms to the gateway", () => {
+    expect(toHttpUrl(`fs:/ipfs/${CID_V0}`)).toBe(GATEWAY_URL);
+    expect(toHttpUrl(`fs://ipfs/${CID_V0}`)).toBe(GATEWAY_URL);
+  });
+
+  it("resolves bare hashes to the gateway", () => {
+    expect(toHttpUrl(CID_V0)).toBe(GATEWAY_URL);
+    expect(toHttpUrl(`${CID_V0}/file.json`)).toBe(`${GATEWAY_URL}/file.json`);
+  });
+
+  it("returns absolute http(s) URLs unchanged", () => {
+    const curateURL = "https://curate.kleros.io/tcr/1/0x6e31D83B0c696f7D57241d3DffD0f2B628D14C67";
+    expect(toHttpUrl(curateURL)).toBe(curateURL);
+    expect(toHttpUrl("http://google.com")).toBe("http://google.com");
+  });
+
+  it("returns undefined for empty or non-string input", () => {
+    expect(toHttpUrl("")).toBeUndefined();
+    expect(toHttpUrl(null)).toBeUndefined();
+    expect(toHttpUrl(undefined)).toBeUndefined();
+    expect(toHttpUrl(42)).toBeUndefined();
+  });
+});
+
+describe("isContentAddressed", () => {
+  it("accepts all common IPFS URI forms", () => {
+    expect(isContentAddressed(`/ipfs/${CID_V0}`)).toBe(true);
+    expect(isContentAddressed(`ipfs/${CID_V0}`)).toBe(true);
+    expect(isContentAddressed(`ipfs://${CID_V1}`)).toBe(true);
+    expect(isContentAddressed(`ipfs:${CID_V0}`)).toBe(true);
+    expect(isContentAddressed(`fs:/ipfs/${CID_V0}`)).toBe(true);
+  });
+
+  it("accepts bare CIDv0 and base32 CIDv1 hashes, with or without a path", () => {
+    expect(isContentAddressed(CID_V0)).toBe(true);
+    expect(isContentAddressed(CID_V1)).toBe(true);
+    expect(isContentAddressed(`${CID_V0}/file.json`)).toBe(true);
+  });
+
+  it("rejects host-anchored and mutable URIs", () => {
+    expect(isContentAddressed(`https://cdn.kleros.link/ipfs/${CID_V1}`)).toBe(false);
+    expect(isContentAddressed("http://example.com")).toBe(false);
+    expect(isContentAddressed("ipns://k51qzi5uqu5dgutdk6i1ynyzg")).toBe(false);
+    expect(isContentAddressed("/ipns/k51qzi5uqu5dgutdk6i1ynyzg")).toBe(false);
+  });
+
+  it("rejects strings that only resemble hashes", () => {
+    expect(isContentAddressed("Qmtooshort")).toBe(false);
+    expect(isContentAddressed(`${CID_V0}X`)).toBe(false);
+    expect(isContentAddressed("whatever")).toBe(false);
+    expect(isContentAddressed("some random text")).toBe(false);
+  });
+
+  it("rejects empty or non-string input", () => {
+    expect(isContentAddressed("")).toBe(false);
+    expect(isContentAddressed(null)).toBe(false);
+    expect(isContentAddressed(undefined)).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9056,12 +9056,7 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.6"
-  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz"
-  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
-
-graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==


### PR DESCRIPTION
Resolves #593.

**NOTE:** credit to @programmaman for identifying the issue and proposing a solution on #592. We decided to go in a different direction, covering additional call sites and adding a validation policy.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing IPFS (InterPlanetary File System) handling in the codebase by introducing a new `IPFS_GATEWAY`, modifying existing functions to use this gateway, and adding utility functions for IPFS URI management.

### Detailed summary
- Added `"test"` script to `package.json`.
- Introduced `graceful-fs` version `^4.2.11` in `resolutions`.
- Replaced hardcoded IPFS endpoint with `IPFS_GATEWAY` in various components.
- Created utility functions in `src/utils/ipfs.js` for IPFS URI handling.
- Updated tests for new IPFS utility functions in `src/utils/ipfs.test.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized IPFS-to-HTTP link generation across the app via a shared gateway helper.
  * Centralized snapshot URL construction to use the configured IPFS gateway.
* **Bug Fixes**
  * Prevented non-content-addressed IPFS resources from being fetched/loaded across policy, evidence, attachments, dynamic scripts, and related iframes.
  * Broadened attachment link disabling when content-addressed validation fails.
  * Evidence/policy resolution now fails safely by returning the existing “Invalid Court Data” behavior.
* **Tests**
  * Added unit tests for IPFS URL parsing/validation utilities.
* **Chores**
  * Added a non-watch `test` script; pinned `graceful-fs` via resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->