### PR TITLE
fix: ignore reserved zero ruling

### DIFF
--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components/macro";
-import { Alert, Button, Card, Checkbox, Col, DatePicker, Icon, Input, Row, Spin, Radio } from "antd";
+import { Alert, Button, Card, Checkbox, Col, DatePicker, Icon, Input, Radio, Row, Spin } from "antd";
 import InputNumber from "rc-input-number";
 import BigNumber from "bignumber.js";
 import { drizzleReactHooks } from "@drizzle/react-plugin";
@@ -16,7 +16,7 @@ import { ReactComponent as Scales } from "../assets/images/scales.svg";
 import { postJustification } from "../bootstrap/api";
 import { useDataloader, useEvidence, VIEW_ONLY_ADDRESS } from "../bootstrap/dataloader";
 import web3Salt from "../temp/web3-salt";
-import { range, binaryPermutations } from "../helpers/array";
+import { binaryPermutations, range } from "../helpers/array";
 import useChainId from "../hooks/use-chain-id";
 import Attachment from "./attachment";
 import DisputeTimeline from "./dispute-timeline";
@@ -646,21 +646,23 @@ export default function CaseDetailsCard({ ID }) {
                     ) : null}
                   </div>
 
-                  {Object.entries(metaEvidence.rulingOptions?.reserved ?? {}).map(([ruling, title]) => (
-                    <div key={ruling} style={{ marginTop: "32px" }}>
-                      {Number(dispute.period) < "3" && !votesData.voted ? (
-                        <Button
-                          disabled={!votesData.canVote}
-                          ghost={votesData.canVote}
-                          id={ruling}
-                          onClick={onVoteClick}
-                          size="large"
-                        >
-                          {title}
-                        </Button>
-                      ) : null}
-                    </div>
-                  ))}
+                  {Object.entries(metaEvidence.rulingOptions?.reserved ?? {})
+                    .filter(([ruling]) => ruling !== "0")
+                    .map(([ruling, title]) => (
+                      <div key={ruling} style={{ marginTop: "32px" }}>
+                        {Number(dispute.period) < "3" && !votesData.voted ? (
+                          <Button
+                            disabled={!votesData.canVote}
+                            ghost={votesData.canVote}
+                            id={ruling}
+                            onClick={onVoteClick}
+                            size="large"
+                          >
+                            {title}
+                          </Button>
+                        ) : null}
+                      </div>
+                    ))}
                 </StyledDiv>
               </>
             ) : (

--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -106,13 +106,15 @@ export default function CaseRoundHistory({ ID, dispute, ruling }) {
                         </Col>
                       ))}
                     {metaEvidence.rulingOptions?.reserved &&
-                      Object.keys(metaEvidence.rulingOptions.reserved).map((key) => (
-                        <Col lg={24} key={key}>
-                          <Radio.Button size="large" value={key}>
-                            {metaEvidence.rulingOptions.reserved[key]}
-                          </Radio.Button>
-                        </Col>
-                      ))}
+                      Object.keys(metaEvidence.rulingOptions.reserved)
+                        .filter((key) => key !== "0")
+                        .map((key) => (
+                          <Col lg={24} key={key}>
+                            <Radio.Button size="large" value={key}>
+                              {metaEvidence.rulingOptions.reserved[key]}
+                            </Radio.Button>
+                          </Col>
+                        ))}
                   </Row>
                 </StyledRadioGroup>
               </RulingOptionsBox>


### PR DESCRIPTION
Correctly filter the reserve "0" button when parsing metaevidence json

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on filtering out reserved ruling options with a key of `"0"` in the `case-round-history.js` and `case-details-card.jsx` components to improve the handling of voting options.

### Detailed summary
- In `case-round-history.js`, added a filter to exclude the key `"0"` from `metaEvidence.rulingOptions.reserved`.
- In `case-details-card.jsx`, implemented a similar filter in the mapping of `metaEvidence.rulingOptions.reserved` to exclude the key `"0"`.
- Rearranged the import statements in `case-details-card.jsx` for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the “0” reserved ruling option from appearing twice in case-related voting and details views.
  * Ensured this option is shown only through its dedicated button, improving clarity and reducing duplicate actions.
  * Updated reserved option lists so only valid choices are rendered in case history and card displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->