### PR TITLE
fix: properly decode ruling text in evidence timeline

### DIFF
--- a/src/components/evidence-timeline.js
+++ b/src/components/evidence-timeline.js
@@ -3,6 +3,7 @@ import React from "react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "styled-components";
 import EvidenceCard from "./evidence-card";
+import { getAnswerString, RTA_LABEL } from "../temp/answer-string";
 
 const StyledHeaderCol = styled(Col)`
   color: ${({ theme }) => theme.textPrimary};
@@ -24,7 +25,7 @@ const EventDiv = styled.div`
   line-height: 14px;
   margin-left: auto;
   margin-right: auto;
-  padding: 10px 0;
+  padding: 10px 5px;
   text-align: center;
   width: 135px;
 `;
@@ -45,11 +46,15 @@ const StyledEvidenceTimelineArea = styled.div`
 `;
 
 const getRulingText = (ruling, metaEvidence) => {
-  if (!ruling) {
-    return "Jurors refused to make a ruling";
+  if (ruling === "0") {
+    return `Jurors ruled: ${RTA_LABEL}`;
   }
-  const rulingIndex = Number(ruling) - 1;
-  const rulingTitle = metaEvidence.rulingOptions?.titles?.[rulingIndex];
+  let rulingTitle;
+  try {
+    rulingTitle = metaEvidence.rulingOptions && getAnswerString(metaEvidence.rulingOptions, ruling);
+  } catch {
+    rulingTitle = undefined;
+  }
   return `Jurors ruled: ${rulingTitle || ruling}`;
 };
 


### PR DESCRIPTION
Resolves #599.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `evidence-timeline.js` file to improve the handling of rulings and refine styling.

### Detailed summary
- Added imports for `getAnswerString` and `RTA_LABEL`.
- Adjusted padding in the styled component `EventDiv`.
- Changed the condition in `getRulingText` to check if `ruling` equals `"0"`.
- Updated the return statement in `getRulingText` to include `RTA_LABEL`.
- Enhanced error handling in `getRulingText` when fetching `rulingTitle`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evidence timeline ruling text to display special ruling values correctly.
  * Added a fallback for cases where ruling details cannot be resolved.

* **Style**
  * Adjusted timeline event spacing for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->