### PR TITLE
fix: improve ruling handling in dispute history section

### DIFF
--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -194,15 +194,21 @@ const RevealVoteButton = ({ onRevealClick, votesData, dispute }) => {
   );
 };
 
-const AnswerDisplay = ({ msg, vote, rulingOptions, uintDisplayMode }) => (
-  <>
-    {msg}
-    {vote === "0"
-      ? RTA_LABEL
-      : (rulingOptions && getAnswerString(rulingOptions, vote, uintDisplayMode)) || "Unknown Choice"}
-    &rdquo;.
-  </>
-);
+const AnswerDisplay = ({ msg, vote, rulingOptions, uintDisplayMode }) => {
+  let answerString;
+  try {
+    answerString = rulingOptions && getAnswerString(rulingOptions, vote, uintDisplayMode);
+  } catch {
+    answerString = undefined;
+  }
+  return (
+    <>
+      {msg}
+      {vote === "0" ? RTA_LABEL : answerString || "Unknown Choice"}
+      &rdquo;.
+    </>
+  );
+};
 
 export default function CaseDetailsCard({ ID }) {
   const { drizzle, useCacheCall, useCacheSend } = useDrizzle();

--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -22,18 +22,19 @@ const normalizeRulingValue = (value) => {
   }
 };
 
+const resolveRulingOption = (ruling) => (ruling == null ? null : normalizeRulingValue(ruling));
+
 export default function CaseRoundHistory({ ID, dispute, ruling }) {
   const { drizzle, useCacheCall } = useDrizzle();
   const getMetaEvidence = useDataloader.getMetaEvidence();
   const [round, setRound] = useState(dispute.votesLengths.length - 1);
-  const [rulingOption, setRulingOption] = useState(ruling == null ? "1" : normalizeRulingValue(ruling));
+  const [rulingOption, setRulingOption] = useState(resolveRulingOption(ruling));
   const [justificationIndex, setJustificationIndex] = useState(0);
   const chainId = useChainId();
 
   useEffect(() => {
-    if (ruling != null) {
-      setRulingOption(normalizeRulingValue(ruling));
-    }
+    setRulingOption(resolveRulingOption(ruling));
+    setJustificationIndex(0);
   }, [ruling]);
 
   const metaEvidence = getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);

--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -8,15 +8,17 @@ import useChainId from "../hooks/use-chain-id";
 import ScrollBar from "./scroll-bar";
 import axios from "axios";
 import useSWR from "swr";
+import Web3 from "web3";
 import { RTA_LABEL } from "../temp/answer-string";
 
 const { useDrizzle } = drizzleReactHooks;
+const { toBN } = Web3.utils;
 
 export default function CaseRoundHistory({ ID, dispute, ruling }) {
   const { drizzle, useCacheCall } = useDrizzle();
   const getMetaEvidence = useDataloader.getMetaEvidence();
   const [round, setRound] = useState(dispute.votesLengths.length - 1);
-  const [rulingOption, setRulingOption] = useState(ruling || 1);
+  const [rulingOption, setRulingOption] = useState(ruling || "1");
   const [justificationIndex, setJustificationIndex] = useState(0);
   const chainId = useChainId();
 
@@ -108,7 +110,7 @@ export default function CaseRoundHistory({ ID, dispute, ruling }) {
                     {metaEvidence.rulingOptions?.reserved &&
                       Object.keys(metaEvidence.rulingOptions.reserved).map((key) => (
                         <Col lg={24} key={key}>
-                          <Radio.Button size="large" value={key}>
+                          <Radio.Button size="large" value={toBN(key).toString()}>
                             {metaEvidence.rulingOptions.reserved[key]}
                           </Radio.Button>
                         </Col>

--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -18,7 +18,7 @@ export default function CaseRoundHistory({ ID, dispute, ruling }) {
   const { drizzle, useCacheCall } = useDrizzle();
   const getMetaEvidence = useDataloader.getMetaEvidence();
   const [round, setRound] = useState(dispute.votesLengths.length - 1);
-  const [rulingOption, setRulingOption] = useState(ruling || "1");
+  const [rulingOption, setRulingOption] = useState(ruling == null ? "1" : toBN(ruling).toString());
   const [justificationIndex, setJustificationIndex] = useState(0);
   const chainId = useChainId();
 

--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import t from "prop-types";
 import styled from "styled-components/macro";
 import { Col, Radio, Row, Skeleton } from "antd";
@@ -14,13 +14,27 @@ import { RTA_LABEL } from "../temp/answer-string";
 const { useDrizzle } = drizzleReactHooks;
 const { toBN } = Web3.utils;
 
+const normalizeRulingValue = (value) => {
+  try {
+    return toBN(value).toString();
+  } catch {
+    return String(value);
+  }
+};
+
 export default function CaseRoundHistory({ ID, dispute, ruling }) {
   const { drizzle, useCacheCall } = useDrizzle();
   const getMetaEvidence = useDataloader.getMetaEvidence();
   const [round, setRound] = useState(dispute.votesLengths.length - 1);
-  const [rulingOption, setRulingOption] = useState(ruling == null ? "1" : toBN(ruling).toString());
+  const [rulingOption, setRulingOption] = useState(ruling == null ? "1" : normalizeRulingValue(ruling));
   const [justificationIndex, setJustificationIndex] = useState(0);
   const chainId = useChainId();
+
+  useEffect(() => {
+    if (ruling != null) {
+      setRulingOption(normalizeRulingValue(ruling));
+    }
+  }, [ruling]);
 
   const metaEvidence = getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
 
@@ -110,7 +124,7 @@ export default function CaseRoundHistory({ ID, dispute, ruling }) {
                     {metaEvidence.rulingOptions?.reserved &&
                       Object.keys(metaEvidence.rulingOptions.reserved).map((key) => (
                         <Col lg={24} key={key}>
-                          <Radio.Button size="large" value={toBN(key).toString()}>
+                          <Radio.Button size="large" value={normalizeRulingValue(key)}>
                             {metaEvidence.rulingOptions.reserved[key]}
                           </Radio.Button>
                         </Col>


### PR DESCRIPTION
Resolves #601.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the error handling and normalization of ruling options in the `AnswerDisplay` and `CaseRoundHistory` components. It improves the robustness of the code by adding try-catch blocks and refactoring how ruling values are processed.

### Detailed summary
- In `AnswerDisplay`, wrapped the logic for obtaining `answerString` in a try-catch block to handle potential errors.
- Updated the return statement to ensure a fallback value for `answerString`.
- In `CaseRoundHistory`, introduced a `normalizeRulingValue` function to convert ruling values using `Web3.utils.toBN` safely.
- Changed the initial state of `rulingOption` to use `resolveRulingOption` for better normalization.
- Added a `useEffect` hook to update `rulingOption` and reset `justificationIndex` whenever `ruling` changes.
- Updated the value in the `Radio.Button` to use the normalized ruling value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reserved ruling option selection to keep the correct choice selected in case round history.
  * Standardized ruling option value formatting so displayed and active options stay aligned.
  * Kept the selected ruling option synchronized when the underlying ruling changes.
  * Improved answer rendering resilience: if answer text can’t be derived, the UI now safely falls back to “Unknown Choice.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->