### PR TITLE
chore: update block explorer URL for gnosis to gnosis.blockscout

### DIFF
--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -98,7 +98,7 @@ const chainIdToParams = {
   100: {
     contractAddress: "0xf1A9589880DbF393F32A5b2d5a0054Fa10385074",
     snapshots: snapshotsByChainId["100"],
-    blockExplorerBaseUrl: "https://gnosisscan.io",
+    blockExplorerBaseUrl: "https://gnosis.blockscout.com",
     klerosboard: klerosboardSubgraph[100],
   },
 };

--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -345,7 +345,7 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
             target="_blank"
             rel="noopener noreferrer"
           >
-            View Transaction on Etherscan <RightArrow style={{ marginLeft: "4px", verticalAlign: "middle" }} />
+            View Transaction <RightArrow style={{ marginLeft: "4px", verticalAlign: "middle" }} />
           </a>
         )}
 

--- a/src/helpers/block-explorer.js
+++ b/src/helpers/block-explorer.js
@@ -1,6 +1,6 @@
 const chainIdToBaseUrl = {
   1: "https://etherscan.io",
-  100: "https://gnosisscan.io",
+  100: "https://gnosis.blockscout.com",
   10200: "https://blockscout.chiadochain.net",
   11155111: "https://sepolia.etherscan.io",
 };


### PR DESCRIPTION
Resolves #604.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the block explorer URLs from `gnosisscan.io` to `gnosis.blockscout.com` in two files, ensuring that the correct links are used for transaction viewing.

### Detailed summary
- Updated block explorer URL in `src/helpers/block-explorer.js` from `https://gnosisscan.io` to `https://gnosis.blockscout.com`.
- Updated `blockExplorerBaseUrl` in `src/components/claim-modal.js` from `https://gnosisscan.io` to `https://gnosis.blockscout.com`.
- Changed the link text in `src/components/claim-modal.js` from "View Transaction on Etherscan" to "View Transaction".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Gnosis transaction and address links to use the current Blockscout explorer domain.
  * Improved the claim modal “View Transaction” link so it points to the correct destination and uses a generic label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->