### PR TITLE
feat: implement caching for MetaEvidence

### DIFF
--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -31,23 +31,36 @@ const META_EVIDENCE_CACHE_PREFIX = "@@kleros/court/metaevidence/v1";
 const metaEvidenceCacheKey = (chainID, arbitrator, disputeId) =>
   `${META_EVIDENCE_CACHE_PREFIX}/${chainID}/${arbitrator}/${disputeId}`;
 
+//MetaEvidence must be an object with at least a title or rulingOptions.
+const isValidMetaEvidence = (metaEvidenceJSON) =>
+  Boolean(metaEvidenceJSON) &&
+  typeof metaEvidenceJSON === "object" &&
+  Boolean(metaEvidenceJSON.title || metaEvidenceJSON.rulingOptions);
+
 const readCachedMetaEvidence = (chainID, arbitrator, disputeId) => {
+  const cacheKey = metaEvidenceCacheKey(chainID, arbitrator, disputeId);
+
   try {
-    const cached = window.localStorage.getItem(metaEvidenceCacheKey(chainID, arbitrator, disputeId));
-    return cached ? JSON.parse(cached) : undefined;
+    const cached = window.localStorage.getItem(cacheKey);
+    if (!cached) return undefined;
+
+    const parsed = JSON.parse(cached);
+    if (isValidMetaEvidence(parsed)) return parsed;
   } catch {
-    return undefined;
+    //Unparsable entry, clean up will happen next.
   }
+
+  try {
+    window.localStorage.removeItem(cacheKey);
+  } catch {
+    //Storage unavailable, so nothing to clean up.
+  }
+  return undefined;
 };
 
 const writeCachedMetaEvidence = (chainID, arbitrator, disputeId, metaEvidenceJSON) => {
   //A malformed response, even with status 200 must not be cached
-  if (
-    !metaEvidenceJSON ||
-    typeof metaEvidenceJSON !== "object" ||
-    (!metaEvidenceJSON.title && !metaEvidenceJSON.rulingOptions)
-  )
-    return;
+  if (!isValidMetaEvidence(metaEvidenceJSON)) return;
 
   try {
     window.localStorage.setItem(metaEvidenceCacheKey(chainID, arbitrator, disputeId), JSON.stringify(metaEvidenceJSON));
@@ -61,24 +74,42 @@ const writeCachedMetaEvidence = (chainID, arbitrator, disputeId, metaEvidenceJSO
 //and it would leave earlier cases, for which the fetch had finished, hanging, possibly forever if one of the other requests failed.
 let dynamicScriptTargetCounter = 0;
 
+//A script that errors inside its iframe never posts a result, which would leave the promise, the
+//listener and the iframe allocated forever. The timeout must exceed getMetaEvidence's retry window
+//so a timed-out scan falls out of the retry loop instead of being re-run from scratch.
+const DYNAMIC_SCRIPT_TIMEOUT_MS = 180000;
+
 const fetchDataFromScript = async (scriptString, scriptParameters) => {
   const { default: iframe } = await import("iframe");
 
   const messageTarget = `script-${dynamicScriptTargetCounter++}`;
 
   let resolver;
-  const returnPromise = new Promise((resolve) => {
+  let rejecter;
+  const returnPromise = new Promise((resolve, reject) => {
     resolver = resolve;
+    rejecter = reject;
   });
 
+  const cleanup = () => {
+    clearTimeout(timeoutId);
+    window.removeEventListener("message", handleScriptMessage);
+    _.iframe.remove();
+  };
+
   const handleScriptMessage = (message) => {
-    if (message.data?.target === messageTarget) {
-      window.removeEventListener("message", handleScriptMessage);
-      _.iframe.remove();
+    //Only accept results posted by this request's own iframe.
+    if (message.source === _.iframe.contentWindow && message.data?.target === messageTarget) {
+      cleanup();
       resolver(message.data.result);
     }
   };
   window.addEventListener("message", handleScriptMessage);
+
+  const timeoutId = setTimeout(() => {
+    cleanup();
+    rejecter(new Error(`The dynamic script for dispute ${scriptParameters.disputeID} timed out.`));
+  }, DYNAMIC_SCRIPT_TIMEOUT_MS);
   const frameBody = `<script type='text/javascript'>
   (function rpcRedirectPatch() {
     const OLD_RPC = "https://mainnet.infura.io/v3/668b3268d5b241b5bab5c6cb886e4c61";

--- a/src/bootstrap/dataloader.js
+++ b/src/bootstrap/dataloader.js
@@ -26,19 +26,59 @@ const getHttpUri = (uri) => {
   }
 };
 
+const META_EVIDENCE_CACHE_PREFIX = "@@kleros/court/metaevidence/v1";
+
+const metaEvidenceCacheKey = (chainID, arbitrator, disputeId) =>
+  `${META_EVIDENCE_CACHE_PREFIX}/${chainID}/${arbitrator}/${disputeId}`;
+
+const readCachedMetaEvidence = (chainID, arbitrator, disputeId) => {
+  try {
+    const cached = window.localStorage.getItem(metaEvidenceCacheKey(chainID, arbitrator, disputeId));
+    return cached ? JSON.parse(cached) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const writeCachedMetaEvidence = (chainID, arbitrator, disputeId, metaEvidenceJSON) => {
+  //A malformed response, even with status 200 must not be cached
+  if (
+    !metaEvidenceJSON ||
+    typeof metaEvidenceJSON !== "object" ||
+    (!metaEvidenceJSON.title && !metaEvidenceJSON.rulingOptions)
+  )
+    return;
+
+  try {
+    window.localStorage.setItem(metaEvidenceCacheKey(chainID, arbitrator, disputeId), JSON.stringify(metaEvidenceJSON));
+  } catch {
+    //Caching is best-effort
+  }
+};
+
+//Each concurrent fetch spawns its own iframe, so responses are tagged with a target counter.
+//Previously, the single shared `window.onmessage` handler would get flooded by calls,
+//and it would leave earlier cases, for which the fetch had finished, hanging, possibly forever if one of the other requests failed.
+let dynamicScriptTargetCounter = 0;
+
 const fetchDataFromScript = async (scriptString, scriptParameters) => {
   const { default: iframe } = await import("iframe");
+
+  const messageTarget = `script-${dynamicScriptTargetCounter++}`;
 
   let resolver;
   const returnPromise = new Promise((resolve) => {
     resolver = resolve;
   });
 
-  window.onmessage = (message) => {
-    if (message.data.target === "script") {
+  const handleScriptMessage = (message) => {
+    if (message.data?.target === messageTarget) {
+      window.removeEventListener("message", handleScriptMessage);
+      _.iframe.remove();
       resolver(message.data.result);
     }
   };
+  window.addEventListener("message", handleScriptMessage);
   const frameBody = `<script type='text/javascript'>
   (function rpcRedirectPatch() {
     const OLD_RPC = "https://mainnet.infura.io/v3/668b3268d5b241b5bab5c6cb886e4c61";
@@ -80,7 +120,7 @@ const fetchDataFromScript = async (scriptString, scriptParameters) => {
 
     returnPromise.then(result => {window.parent.postMessage(
       {
-        target: 'script',
+        target: ${JSON.stringify(messageTarget)},
         result
       },
       '*'
@@ -106,7 +146,10 @@ const fetchDataFromScript = async (scriptString, scriptParameters) => {
 };
 
 const funcs = {
-  async getMetaEvidence(chainID, arbitrated, arbitrator, disputeId) {
+  async getMetaEvidence(chainID, arbitrated, arbitrator, disputeId, ruled) {
+    const cached = readCachedMetaEvidence(chainID, arbitrator, disputeId);
+    if (cached) return cached;
+
     const startTime = Date.now();
     const maxTime = 120000;
     const waitTime = 5000;
@@ -191,6 +234,9 @@ const funcs = {
           };
         }
 
+        //Ruled disputes are final, their metaEvidence can never change and is safe to cache.
+        if (ruled) writeCachedMetaEvidence(chainID, arbitrator, disputeId, metaEvidenceJSON);
+
         return metaEvidenceJSON;
       } catch (err) {
         await new Promise((r) => setTimeout(() => r(), waitTime));
@@ -232,7 +278,10 @@ const funcs = {
 };
 
 export const dataloaders = Object.keys(funcs).reduce((acc, f) => {
+  //Batching is disabled because the loaders gain nothing from it (each key is fetched independently)
+  //A single hanging dynamic script would keep all the other cards of a cases list stuck on their skeletons.
   acc[f] = new Dataloader((argsArr) => Promise.all(argsArr.map((args) => funcs[f](...args))), {
+    batch: false,
     cacheKeyFn: JSON.stringify,
   });
   return acc;

--- a/src/bootstrap/dataloader.test.js
+++ b/src/bootstrap/dataloader.test.js
@@ -61,6 +61,24 @@ describe("Dataloader", () => {
     expect(axios.get).toHaveBeenCalledTimes(2);
   });
 
+  it("discards a cached entry with an invalid shape, refetches and overwrites it", async () => {
+    const cacheKey = `@@kleros/court/metaevidence/v1/${CHAIN_ID}/${ARBITRATOR}/${DISPUTE_ID}`;
+    window.localStorage.setItem(cacheKey, JSON.stringify({ foo: "bar" }));
+
+    const result = await loadMetaEvidence(true);
+    expect(result).toMatchObject(META_EVIDENCE_JSON);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(window.localStorage.getItem(cacheKey))).toMatchObject(META_EVIDENCE_JSON);
+  });
+
+  it("removes an invalid cached entry even when the dispute is not ruled", async () => {
+    const cacheKey = `@@kleros/court/metaevidence/v1/${CHAIN_ID}/${ARBITRATOR}/${DISPUTE_ID}`;
+    window.localStorage.setItem(cacheKey, JSON.stringify({ foo: "bar" }));
+
+    await loadMetaEvidence(false);
+    expect(window.localStorage.getItem(cacheKey)).toBeNull();
+  });
+
   it("does not cache a malformed gateway response served with status 200", async () => {
     axios.get.mockImplementation((url) =>
       url.startsWith(process.env.REACT_APP_METAEVIDENCE_URL)

--- a/src/bootstrap/dataloader.test.js
+++ b/src/bootstrap/dataloader.test.js
@@ -1,0 +1,92 @@
+import axios from "axios";
+import { dataloaders } from "./dataloader";
+
+jest.mock("axios", () => ({ get: jest.fn(), post: jest.fn() }));
+jest.mock("./web3", () => ({
+  getReadOnlyRpcUrl: () => "http://localhost:8545",
+}));
+
+//Test values - change if needed
+const CHAIN_ID = 1;
+const ARBITRATED = "0x0000000000000000000000000000000000000001";
+const ARBITRATOR = "0x0000000000000000000000000000000000000002";
+const DISPUTE_ID = "1657";
+const META_EVIDENCE_URI = "/ipfs/QmVkcsYWd22JkG2rq29wQzNeXP5WEZ9vyVrrnhzry5vdHa";
+const META_EVIDENCE_JSON = {
+  title: "A reality.eth question",
+  rulingOptions: { type: "single-select", titles: ["Yes", "No"] },
+};
+
+const loadMetaEvidence = (ruled) =>
+  dataloaders.getMetaEvidence.load([CHAIN_ID, ARBITRATED, ARBITRATOR, DISPUTE_ID, ruled]);
+
+describe("Dataloader", () => {
+  beforeEach(() => {
+    process.env.REACT_APP_METAEVIDENCE_URL = "https://kleros-api.test/get-dispute-metaevidence";
+    window.localStorage.clear();
+    dataloaders.getMetaEvidence.clearAll();
+    axios.get.mockReset();
+    axios.get.mockImplementation((url) =>
+      url.startsWith(process.env.REACT_APP_METAEVIDENCE_URL)
+        ? Promise.resolve({ status: 200, data: { metaEvidenceUri: META_EVIDENCE_URI } })
+        : Promise.resolve({ status: 200, data: { ...META_EVIDENCE_JSON } })
+    );
+  });
+
+  it("caches the result of a ruled dispute and serves the data without extra network requests", async () => {
+    const first = await loadMetaEvidence(true);
+    expect(first).toMatchObject(META_EVIDENCE_JSON);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+
+    dataloaders.getMetaEvidence.clearAll();
+    const second = await loadMetaEvidence(true);
+    expect(second).toEqual(first);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache the result of an unruled dispute", async () => {
+    await loadMetaEvidence(false);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+
+    dataloaders.getMetaEvidence.clearAll();
+    await loadMetaEvidence(false);
+    expect(axios.get).toHaveBeenCalledTimes(4);
+  });
+
+  it("serves a previously cached dispute even when queried as unruled", async () => {
+    await loadMetaEvidence(true);
+
+    dataloaders.getMetaEvidence.clearAll();
+    await loadMetaEvidence(false);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a malformed gateway response served with status 200", async () => {
+    axios.get.mockImplementation((url) =>
+      url.startsWith(process.env.REACT_APP_METAEVIDENCE_URL)
+        ? Promise.resolve({ status: 200, data: { metaEvidenceUri: META_EVIDENCE_URI } })
+        : Promise.resolve({ status: 200, data: "<html>gateway error</html>" })
+    );
+
+    await loadMetaEvidence(true);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+
+    dataloaders.getMetaEvidence.clearAll();
+    await loadMetaEvidence(true);
+    expect(axios.get).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not cache the tamper fallback returned for invalid case data", async () => {
+    axios.get.mockImplementation(() =>
+      Promise.resolve({ status: 200, data: { metaEvidenceUri: "https://example.com/meta.json" } })
+    );
+
+    const result = await loadMetaEvidence(true);
+    expect(result.title).toBe("Invalid or tampered case data, refuse to arbitrate.");
+
+    dataloaders.getMetaEvidence.clearAll();
+    axios.get.mockClear();
+    await loadMetaEvidence(true);
+    expect(axios.get).toHaveBeenCalled();
+  });
+});

--- a/src/components/case-card.js
+++ b/src/components/case-card.js
@@ -21,6 +21,10 @@ const StyledCard = styled(Card).attrs({ className: "purple-header-card" })`
   margin: 20px 0 0;
   text-align: center;
 
+  &.ant-card-loading .ant-card-body {
+    min-height: 225px;
+  }
+
   .ant-card-actions {
     border: none;
     padding: 12px 24px;
@@ -209,7 +213,7 @@ const CaseCard = ({ ID, draws, isVoteCommitted }) => {
   });
 
   const metaEvidence =
-    dispute && getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
+    dispute && getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID, dispute.ruled);
 
   return (
     <StyledCard

--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -301,7 +301,7 @@ export default function CaseDetailsCard({ ID }) {
     }
   });
 
-  const metaEvidence = dispute && getMetaEvidence(chainId, dispute.arbitrated, KlerosLiquid.address, ID);
+  const metaEvidence = dispute && getMetaEvidence(chainId, dispute.arbitrated, KlerosLiquid.address, ID, dispute.ruled);
   const evidence = useEvidence(chainId, ID);
 
   const [showRefuse, setShowRefuse] = useState(false);

--- a/src/components/case-round-history.js
+++ b/src/components/case-round-history.js
@@ -37,7 +37,13 @@ export default function CaseRoundHistory({ ID, dispute, ruling }) {
     setJustificationIndex(0);
   }, [ruling]);
 
-  const metaEvidence = getMetaEvidence(chainId, dispute.arbitrated, drizzle.contracts.KlerosLiquid.address, ID);
+  const metaEvidence = getMetaEvidence(
+    chainId,
+    dispute.arbitrated,
+    drizzle.contracts.KlerosLiquid.address,
+    ID,
+    dispute.ruled
+  );
 
   const { data: justificationsByRound, isLoading } = useSWR(
     metaEvidence && dispute && ID && chainId && ["justifications", chainId, ID, dispute.votesLengths],

--- a/src/components/ongoing-cases-card.js
+++ b/src/components/ongoing-cases-card.js
@@ -91,7 +91,8 @@ const OngoingCasesCard = () => {
                     chainId,
                     dispute.arbitrated,
                     drizzle.contracts.KlerosLiquid.address,
-                    d.disputeID
+                    d.disputeID,
+                    dispute.ruled
                   );
 
                   if (Number(d.appeal) === dispute2.votesLengths.length - 1) {
@@ -123,7 +124,8 @@ const OngoingCasesCard = () => {
                   chainId,
                   dispute.arbitrated,
                   drizzle.contracts.KlerosLiquid.address,
-                  d.disputeID
+                  d.disputeID,
+                  dispute.ruled
                 );
 
                 if (dispute.period === "4")


### PR DESCRIPTION
Resolves #606. 

Also includes:
- Improved data fetching logic, namely when batching dynamic script fetches;
- Minor UI improvements.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `metaEvidence` by including the `ruled` parameter in multiple components. This allows for improved caching and retrieval of evidence related to disputes, ensuring that ruled disputes are efficiently managed.

### Detailed summary
- Added `dispute.ruled` parameter to `getMetaEvidence` calls in `case-details-card.jsx`, `ongoing-cases-card.js`, `case-round-history.js`, and `case-card.js`.
- Implemented caching logic for `metaEvidence` based on whether disputes are ruled in `dataloader.js`.
- Introduced tests in `dataloader.test.js` to validate caching behavior for ruled and unruled disputes.
- Enhanced error handling and cache management for `metaEvidence` in `dataloader.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved meta-evidence caching for ruled disputes to speed up repeat case views.
- **Bug Fixes**
  - Prevented invalid or malformed meta-evidence and response payloads from being saved to cache.
  - Ensured unrulled disputes don’t reuse cached ruled data and continue fetching fresh information when needed.
  - Improved reliability of meta-evidence loading by isolating per-request message handling.
- **UI / Style**
  - Enhanced case card loading layout to keep consistent card body height.
- **Tests**
  - Added Jest coverage for meta-evidence caching, cache invalidation, and non-cached failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->