### PR TITLE
fix: add reward snapshot cache + do not fetch unnecessary metaevidence

### DIFF
--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -186,7 +186,9 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
 
     setClaims(0);
 
-    if (account === VIEW_ONLY_ADDRESS) return;
+    //The view-only placeholder has no claims to resolve.
+    //An empty snapshot list must leave `claims` at its initial 0
+    if (account === VIEW_ONLY_ADDRESS || snapshots.length === 0) return;
 
     loadClaims({
       account,
@@ -324,8 +326,8 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
           </StyledInfoBox>
           {hasUnverifiedWeeks(claims) && (
             <StyledIncompleteNotice>
-              Some monthly rewards could not be checked right now, so the amounts above may be incomplete. They will be
-              rechecked automatically on your next visit.
+              Some monthly rewards could not be checked, so the amounts above may be incomplete. They will be rechecked
+              on reload or next visit.
             </StyledIncompleteNotice>
           )}
         </>

--- a/src/components/claim-modal.js
+++ b/src/components/claim-modal.js
@@ -11,6 +11,7 @@ import useChainId from "../hooks/use-chain-id";
 import ETHAmount from "./eth-amount";
 import { klerosboardSubgraph } from "../bootstrap/subgraph";
 import { IPFS_GATEWAY } from "../utils/ipfs";
+import { loadClaims, hasUnverifiedWeeks } from "../helpers/claim-snapshots";
 import snapshotsByChainId from "../assets/snapshots.json";
 
 const StyledModal = styled(Modal)`
@@ -74,6 +75,13 @@ const StyledUnclaimedAmount = styled.div`
   text-align: right;
 `;
 
+const StyledIncompleteNotice = styled.div`
+  font-size: 14px;
+  color: ${({ theme }) => theme.disabledColor};
+  text-align: center;
+  margin-bottom: 16px;
+`;
+
 const StyledReadMoreLink = styled.div`
   font-size: 18px;
   color: ${({ theme }) => theme.primaryColor};
@@ -120,20 +128,22 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
 
   const claimObjects = (claims) => {
     if (claims.length > 0)
-      return claims
-        .map(
-          (claim, index) =>
-            claim && {
-              week: index,
-              balance: claim.value.hex,
-              merkleProof: claim.proof,
-            }
-        )
-        .filter((claimObject) => typeof claimObject !== "undefined");
+      return (
+        claims
+          .map(
+            (claim, index) =>
+              claim && {
+                week: index,
+                balance: claim.value.hex,
+                merkleProof: claim.proof,
+              }
+          )
+          //Weeks whose snapshot failed to load are 0 in `claims` and they must be excluded
+          .filter(Boolean)
+      );
   };
 
   useEffect(() => {
-    var responses = [];
     const airdropParams = chainIdToParams[chainId];
 
     if (!airdropParams) {
@@ -141,14 +151,6 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
     }
 
     const snapshots = airdropParams?.snapshots ?? [];
-
-    for (var month = 0; month < snapshots.length; month++) {
-      responses[month] = fetch(`${IPFS_GATEWAY}/ipfs/${snapshots[month]}`);
-    }
-
-    const results = Promise.all(
-      responses.map((promise) => promise.then((r) => r.json()).catch((e) => console.error(e)))
-    );
 
     fetch(airdropParams.klerosboard, {
       headers: {
@@ -171,36 +173,34 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
       .then((r) => apyCallback(drizzle.web3.utils.fromWei(r.data.klerosCounters[0].tokenStaked)))
       .catch(() => {
         console.warn("Falling back to last merkle tree for calculating APY");
-        results.then((trees) => {
-          if (trees.length === 0) {
-            console.warn("No snapshot found! Cannot calculate the APY");
-            return;
-          }
+        if (snapshots.length === 0) {
+          console.warn("No snapshot found! Cannot calculate the APY");
+          return;
+        }
 
-          return apyCallback(drizzle.web3.utils.fromWei(trees.slice(-1)[0].averageTotalStaked.hex));
-        });
+        fetch(`${IPFS_GATEWAY}/ipfs/${snapshots[snapshots.length - 1]}`)
+          .then((r) => r.json())
+          .then((tree) => apyCallback(drizzle.web3.utils.fromWei(tree.averageTotalStaked.hex)))
+          .catch((e) => console.error(e));
       });
 
     setClaims(0);
-    results.then((r) =>
-      r.forEach(function (item) {
-        if (item) {
-          apyCallback(item.apy);
-          if (item.merkleTree.claims[account]) displayButton();
-          setClaims((prevState) => {
-            if (prevState) return [...prevState, item.merkleTree.claims[account]];
-            else return [item.merkleTree.claims[account]];
-          });
-        } else
-          setClaims((prevState) => {
-            if (prevState) return [...prevState, 0];
-            else return [0];
-          });
-      })
-    );
+
+    if (account === VIEW_ONLY_ADDRESS) return;
+
+    loadClaims({
+      account,
+      chainId,
+      snapshots,
+      gateway: IPFS_GATEWAY,
+      storage: window.localStorage,
+    }).then((claimsByWeek) => {
+      if (claimsByWeek.some(Boolean)) displayButton();
+      setClaims(claimsByWeek);
+    });
 
     const contract = new drizzle.web3.eth.Contract(MerkleRedeem.abi, airdropParams.contractAddress);
-    const claimStatus = contract.methods.claimStatus(account, 0, chainIdToParams[chainId].snapshots.length).call();
+    const claimStatus = contract.methods.claimStatus(account, 0, snapshots.length).call();
 
     claimStatus.then((r) => setClaimStatus(r));
   }, [account, chainId, drizzle.web3.utils, drizzle.web3.eth.Contract, modalState, apyCallback, displayButton]);
@@ -322,6 +322,12 @@ const ClaimModal = ({ visible, onOk, onCancel, displayButton, apyCallback }) => 
               </StyledUnclaimedAmount>
             </div>
           </StyledInfoBox>
+          {hasUnverifiedWeeks(claims) && (
+            <StyledIncompleteNotice>
+              Some monthly rewards could not be checked right now, so the amounts above may be incomplete. They will be
+              rechecked automatically on your next visit.
+            </StyledIncompleteNotice>
+          )}
         </>
       )}
       {modalState >= 1 && <StyledHr />}

--- a/src/components/ongoing-cases-card.js
+++ b/src/components/ongoing-cases-card.js
@@ -110,7 +110,7 @@ const OngoingCasesCard = () => {
                       ID: d.disputeID,
                     });
                 } else acc.loading = true;
-                //Executed disputes (period 4) are skipped entirely.
+                //Executed disputes are skipped entirely.
                 //This card never renders them and resolving their metaEvidence caused dashboard freezes to some jurors.
               } else if (dispute.period !== "4") {
                 const metaEvidence = getMetaEvidence(

--- a/src/components/ongoing-cases-card.js
+++ b/src/components/ongoing-cases-card.js
@@ -35,15 +35,6 @@ const StyledVoting = styled.div`
     }
   }
 `;
-const StyledExecuted = styled.div`
-  color: ${({ theme }) => theme.dangerColor};
-  svg {
-    height: 12px;
-    path {
-      fill: ${({ theme }) => theme.dangerColor};
-    }
-  }
-`;
 const StyledAppealed = styled.div`
   color: ${({ theme }) => theme.dangerColor};
   svg {
@@ -83,7 +74,7 @@ const OngoingCasesCard = () => {
         ).reduce(
           (acc, d) => {
             const dispute = call("KlerosLiquid", "disputes", d.disputeID);
-            if (dispute)
+            if (dispute) {
               if (dispute.period === "1" || dispute.period === "2") {
                 const dispute2 = call("KlerosLiquid", "getDispute", d.disputeID);
                 if (dispute2) {
@@ -119,7 +110,9 @@ const OngoingCasesCard = () => {
                       ID: d.disputeID,
                     });
                 } else acc.loading = true;
-              } else {
+                //Executed disputes (period 4) are skipped entirely.
+                //This card never renders them and resolving their metaEvidence caused dashboard freezes to some jurors.
+              } else if (dispute.period !== "4") {
                 const metaEvidence = getMetaEvidence(
                   chainId,
                   dispute.arbitrated,
@@ -128,33 +121,22 @@ const OngoingCasesCard = () => {
                   dispute.ruled
                 );
 
-                if (dispute.period === "4")
-                  acc.executed.push({
-                    metaEvidence,
-                    statusDiv: (
-                      <StyledExecuted>
-                        Executed <HourGlass />
-                      </StyledExecuted>
-                    ),
-                    ID: d.disputeID,
-                  });
-                else
-                  acc.active.push({
-                    metaEvidence,
-                    statusDiv: (
-                      <StyledPending>
-                        Pending <HourGlass />
-                      </StyledPending>
-                    ),
-                    ID: d.disputeID,
-                  });
+                acc.active.push({
+                  metaEvidence,
+                  statusDiv: (
+                    <StyledPending>
+                      Pending <HourGlass />
+                    </StyledPending>
+                  ),
+                  ID: d.disputeID,
+                });
               }
-            else acc.loading = true;
+            } else acc.loading = true;
             return acc;
           },
-          { active: [], executed: [], loading: false, votePending: [] }
+          { active: [], loading: false, votePending: [] }
         )
-      : { active: [], executed: [], loading: true, votePending: [] }
+      : { active: [], loading: true, votePending: [] }
   );
 
   const _allActive = disputes.votePending.reverse().concat(disputes.active.reverse());

--- a/src/helpers/claim-snapshots.js
+++ b/src/helpers/claim-snapshots.js
@@ -1,0 +1,106 @@
+//Resolves an account's claim entries from the monthly reward snapshots.
+//Snapshot files are immutable, so can be cached indefinitely and keyed by CID.
+//Claim STATUS is deliberately never cached as it must always be read live from the MerkleRedeem contract.
+
+const CACHE_PREFIX = "@@kleros/court/claim-snapshots/v1";
+
+export const SNAPSHOT_FETCH_TIMEOUT_MS = 30000;
+
+//A gateway request that hangs forever would stall its worker and keep the Claim button pending for
+//the whole session. A timed-out week resolves to 0 like any other failed fetch: excluded from this
+//session's totals, never cached, retried on the next load.
+const fetchTreeWithTimeout = async (fetchFn, url, timeoutMs) => {
+  const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
+  let timer;
+  const timedOut = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      if (controller) controller.abort();
+      reject(new Error(`Timed out fetching ${url} after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    const fetched = (async () => {
+      const response = await fetchFn(url, controller ? { signal: controller.signal } : undefined);
+      return response.json();
+    })();
+    return await Promise.race([fetched, timedOut]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const cacheKey = (chainId, account) => `${CACHE_PREFIX}/${chainId}/${String(account).toLowerCase()}`;
+
+export const hasUnverifiedWeeks = (claims) => Array.isArray(claims) && claims.some((claim) => claim === 0);
+
+export const readCachedClaims = (storage, chainId, account) => {
+  try {
+    const raw = storage.getItem(cacheKey(chainId, account));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+  } catch {
+    //Unreadable cache is treated as empty; it gets overwritten on the next successful load.
+  }
+  return {};
+};
+
+export const writeCachedClaims = (storage, chainId, account, claimsByCid) => {
+  try {
+    storage.setItem(cacheKey(chainId, account), JSON.stringify(claimsByCid));
+  } catch {
+    //Caching is best-effort.
+  }
+};
+
+//Resolves the account's claim entry for every snapshot, index-aligned with `snapshots`.
+//Only snapshots missing from the cache are fetched, at most `concurrency` at a time.
+//The array index is also the on-chain `week` argument of MerkleRedeem.claimWeeks, meaning the output must keep one slot per snapshot.
+//The logic is the following:
+//   - the real merkle claim entry ({ value, proof }) when the account is in that snapshot;
+//   - undefined when the account is not in the snapshot;
+//   - 0 when the snapshot could not be fetched (keep out of the cache so it is retried on the next load).
+export async function loadClaims({
+  account,
+  chainId,
+  snapshots,
+  gateway,
+  storage,
+  concurrency = 6,
+  fetchFn = fetch,
+  timeoutMs = SNAPSHOT_FETCH_TIMEOUT_MS,
+}) {
+  const cached = readCachedClaims(storage, chainId, account);
+  const claimsByWeek = new Array(snapshots.length);
+  const missing = [];
+
+  snapshots.forEach((cid, week) => {
+    //null marks "account not in this snapshot".
+    if (cid in cached) claimsByWeek[week] = cached[cid] === null ? undefined : cached[cid];
+    else missing.push({ cid, week });
+  });
+
+  let cursor = 0;
+  let dirty = false;
+  const worker = async () => {
+    while (cursor < missing.length) {
+      const { cid, week } = missing[cursor++];
+      try {
+        const tree = await fetchTreeWithTimeout(fetchFn, `${gateway}/ipfs/${cid}`, timeoutMs);
+        const entry = tree.merkleTree.claims[account];
+        claimsByWeek[week] = entry;
+        cached[cid] = entry === undefined ? null : entry;
+        dirty = true;
+      } catch (err) {
+        console.error(err);
+        claimsByWeek[week] = 0;
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, missing.length) }, worker));
+
+  if (dirty) writeCachedClaims(storage, chainId, account, cached);
+  return claimsByWeek;
+}

--- a/src/helpers/claim-snapshots.js
+++ b/src/helpers/claim-snapshots.js
@@ -6,9 +6,8 @@ const CACHE_PREFIX = "@@kleros/court/claim-snapshots/v1";
 
 export const SNAPSHOT_FETCH_TIMEOUT_MS = 30000;
 
-//A gateway request that hangs forever would stall its worker and keep the Claim button pending for
-//the whole session. A timed-out week resolves to 0 like any other failed fetch: excluded from this
-//session's totals, never cached, retried on the next load.
+//A request that hangs forever would stall and keep the Claim button pending for the whole session.
+//A timeout resolves to 0 and is excluded from this session's totals, never cached, and retried on the next load.
 const fetchTreeWithTimeout = async (fetchFn, url, timeoutMs) => {
   const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
   let timer;

--- a/src/helpers/claim-snapshots.test.js
+++ b/src/helpers/claim-snapshots.test.js
@@ -1,0 +1,200 @@
+import { hasUnverifiedWeeks, loadClaims, readCachedClaims, writeCachedClaims } from "./claim-snapshots";
+
+const CHAIN_ID = 100;
+const ACCOUNT = "0xAd9F95327af33804D2265a4cC37a4FF867C56954";
+const GATEWAY = "https://cdn.kleros.test";
+
+const CLAIM_A = { value: { hex: "0x0de0b6b3a7640000" }, proof: ["0xaa", "0xbb"] };
+const CLAIM_C = { value: { hex: "0x1bc16d674ec80000" }, proof: ["0xcc"] };
+
+const makeStorage = () => {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    map,
+  };
+};
+
+const makeTree = (claims) => ({ merkleTree: { claims } });
+
+//fetchFn resolving each CID to a fixture tree; rejects for CIDs in `failing`.
+const makeFetchFn = (treesByCid, failing = []) =>
+  jest.fn((url) => {
+    const cid = url.replace(`${GATEWAY}/ipfs/`, "");
+    if (failing.includes(cid)) return Promise.reject(new Error(`fetch failed for ${cid}`));
+    return Promise.resolve({ json: () => Promise.resolve(treesByCid[cid]) });
+  });
+
+const load = (overrides = {}) =>
+  loadClaims({
+    account: ACCOUNT,
+    chainId: CHAIN_ID,
+    snapshots: ["cidA", "cidB", "cidC"],
+    gateway: GATEWAY,
+    storage: overrides.storage ?? makeStorage(),
+    fetchFn: overrides.fetchFn,
+    ...overrides,
+  });
+
+describe("loadClaims", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  const treesByCid = {
+    cidA: makeTree({ [ACCOUNT]: CLAIM_A }),
+    cidB: makeTree({}),
+    cidC: makeTree({ [ACCOUNT]: CLAIM_C }),
+  };
+
+  it("keeps one slot per snapshot, in snapshot order (week-index invariant)", async () => {
+    const claims = await load({ fetchFn: makeFetchFn(treesByCid) });
+
+    expect(claims).toHaveLength(3);
+    expect(claims[0]).toEqual(CLAIM_A);
+    expect(claims[1]).toBeUndefined();
+    expect(claims[2]).toEqual(CLAIM_C);
+  });
+
+  it("serves every snapshot from cache on the second load, with zero fetches", async () => {
+    const storage = makeStorage();
+    const fetchFn = makeFetchFn(treesByCid);
+
+    const first = await load({ storage, fetchFn });
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+
+    const secondFetchFn = makeFetchFn(treesByCid);
+    const second = await load({ storage, fetchFn: secondFetchFn });
+    expect(secondFetchFn).not.toHaveBeenCalled();
+    expect(second).toEqual(first);
+  });
+
+  it("only fetches snapshots missing from the cache (new month appended)", async () => {
+    const storage = makeStorage();
+    await load({ storage, fetchFn: makeFetchFn(treesByCid) });
+
+    const treesWithNewMonth = { ...treesByCid, cidD: makeTree({ [ACCOUNT]: CLAIM_A }) };
+    const fetchFn = makeFetchFn(treesWithNewMonth);
+    const claims = await load({ storage, fetchFn, snapshots: ["cidA", "cidB", "cidC", "cidD"] });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(`${GATEWAY}/ipfs/cidD`, expect.anything());
+    expect(claims).toHaveLength(4);
+    expect(claims[3]).toEqual(CLAIM_A);
+  });
+
+  it("marks failed fetches as 0 in place, does not cache them, and retries next load", async () => {
+    const storage = makeStorage();
+    const claims = await load({ storage, fetchFn: makeFetchFn(treesByCid, ["cidB"]) });
+
+    expect(claims).toEqual([CLAIM_A, 0, CLAIM_C]);
+
+    const retryFetchFn = makeFetchFn(treesByCid);
+    const retried = await load({ storage, fetchFn: retryFetchFn });
+    expect(retryFetchFn).toHaveBeenCalledTimes(1);
+    expect(retryFetchFn).toHaveBeenCalledWith(`${GATEWAY}/ipfs/cidB`, expect.anything());
+    expect(retried).toEqual([CLAIM_A, undefined, CLAIM_C]);
+  });
+
+  it("treats a malformed snapshot as a failed fetch for that week only", async () => {
+    const claims = await load({
+      fetchFn: makeFetchFn({ ...treesByCid, cidB: { notATree: true } }),
+    });
+
+    expect(claims).toEqual([CLAIM_A, 0, CLAIM_C]);
+  });
+
+  it("times out a hung fetch, marks that week 0, and retries it next load", async () => {
+    const storage = makeStorage();
+    const hangingFetchFn = jest.fn((url) => {
+      if (url.endsWith("cidB")) return new Promise(() => {});
+      return makeFetchFn(treesByCid)(url);
+    });
+
+    const claims = await load({ storage, fetchFn: hangingFetchFn, timeoutMs: 25 });
+    expect(claims).toEqual([CLAIM_A, 0, CLAIM_C]);
+
+    const retryFetchFn = makeFetchFn(treesByCid);
+    const retried = await load({ storage, fetchFn: retryFetchFn });
+    expect(retryFetchFn).toHaveBeenCalledTimes(1);
+    expect(retried).toEqual([CLAIM_A, undefined, CLAIM_C]);
+  });
+
+  it("never runs more than `concurrency` fetches at once", async () => {
+    const snapshots = Array.from({ length: 20 }, (_, i) => `cid${i}`);
+    let active = 0;
+    let maxActive = 0;
+    const fetchFn = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          setTimeout(() => {
+            active--;
+            resolve({ json: () => Promise.resolve(makeTree({})) });
+          }, 0);
+        })
+    );
+
+    await load({ snapshots, fetchFn, concurrency: 4 });
+
+    expect(fetchFn).toHaveBeenCalledTimes(20);
+    expect(maxActive).toBeLessThanOrEqual(4);
+  });
+
+  it("keeps separate caches per account and per chain", async () => {
+    const storage = makeStorage();
+    await load({ storage, fetchFn: makeFetchFn(treesByCid) });
+
+    const otherAccountFetchFn = makeFetchFn(treesByCid);
+    await load({ storage, fetchFn: otherAccountFetchFn, account: "0x0000000000000000000000000000000000000001" });
+    expect(otherAccountFetchFn).toHaveBeenCalledTimes(3);
+
+    const otherChainFetchFn = makeFetchFn(treesByCid);
+    await load({ storage, fetchFn: otherChainFetchFn, chainId: 1 });
+    expect(otherChainFetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("survives a corrupt cache entry by refetching everything", async () => {
+    const storage = makeStorage();
+    writeCachedClaims(storage, CHAIN_ID, ACCOUNT, "not-an-object");
+
+    const fetchFn = makeFetchFn(treesByCid);
+    const claims = await load({ storage, fetchFn });
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(claims[0]).toEqual(CLAIM_A);
+  });
+});
+
+describe("hasUnverifiedWeeks", () => {
+  it("flags only arrays containing a failed (0) week", () => {
+    expect(hasUnverifiedWeeks([CLAIM_A, 0, undefined])).toBe(true);
+    expect(hasUnverifiedWeeks([CLAIM_A, undefined])).toBe(false);
+    expect(hasUnverifiedWeeks([])).toBe(false);
+    expect(hasUnverifiedWeeks(0)).toBe(false); //initial component state before any load
+  });
+});
+
+describe("cache read/write", () => {
+  it("round-trips claims and tolerates unavailable storage", () => {
+    const storage = makeStorage();
+    writeCachedClaims(storage, CHAIN_ID, ACCOUNT, { cidA: CLAIM_A, cidB: null });
+    expect(readCachedClaims(storage, CHAIN_ID, ACCOUNT)).toEqual({ cidA: CLAIM_A, cidB: null });
+
+    const broken = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    };
+    expect(readCachedClaims(broken, CHAIN_ID, ACCOUNT)).toEqual({});
+    expect(() => writeCachedClaims(broken, CHAIN_ID, ACCOUNT, {})).not.toThrow();
+  });
+});

--- a/src/helpers/claim-snapshots.test.js
+++ b/src/helpers/claim-snapshots.test.js
@@ -125,6 +125,16 @@ describe("loadClaims", () => {
     expect(retried).toEqual([CLAIM_A, undefined, CLAIM_C]);
   });
 
+  it("returns an empty array for an empty snapshot list without fetching or caching", async () => {
+    const storage = makeStorage();
+    const fetchFn = jest.fn();
+
+    const claims = await load({ storage, fetchFn, snapshots: [] });
+    expect(claims).toEqual([]);
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(storage.map.size).toBe(0);
+  });
+
   it("never runs more than `concurrency` fetches at once", async () => {
     const snapshots = Array.from({ length: 20 }, (_, i) => `cid${i}`);
     let active = 0;


### PR DESCRIPTION
Resolves #612.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of claims in the Kleros dashboard. It introduces caching mechanisms, modifies dispute handling, and enhances user notifications for incomplete claims.

### Detailed summary
- Removed `StyledExecuted` component and related dispute handling.
- Updated `OngoingCasesCard` to skip executed disputes.
- Added caching for claim snapshots in `claim-snapshots.js`.
- Implemented `loadClaims` function to fetch and manage claims with timeouts.
- Introduced `StyledIncompleteNotice` in `ClaimModal` for user notifications.
- Enhanced tests for claim loading and caching behaviors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claim snapshots now load faster with local caching and concurrent retrieval.
  * Incomplete or unverified claim data displays a notice.
  * View-only accounts no longer load claim details.
  * Missing or unavailable snapshot data is handled gracefully.

* **Bug Fixes**
  * Removed completed disputes from ongoing-case displays.
  * Period-4 disputes are no longer shown as active.
  * Improved handling of missing dispute and snapshot information.

* **Tests**
  * Added coverage for caching, timeouts, failed requests, malformed data, and week verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->