### PR TITLE
refactor: remove caption next to justification box

### DIFF
--- a/src/components/case-details-card.jsx
+++ b/src/components/case-details-card.jsx
@@ -647,12 +647,7 @@ export default function CaseDetailsCard({ ID }) {
                   {votesData.drawnInCurrentRound &&
                     dispute.period === "1" &&
                     subcourts[subcourts.length - 1].hiddenVotes && (
-                      <>
-                        <JustificationBox onChange={onJustificationChange} justification={justification} />
-                        <StyledJustificationNote>
-                          Saved on this device only. You will be able to review and submit it when you reveal your vote.
-                        </StyledJustificationNote>
-                      </>
+                      <JustificationBox onChange={onJustificationChange} justification={justification} />
                     )}
                   {Number(dispute.period) < 3 && !votesData.voted && metaEvidence.rulingOptions ? (
                     votesData.committed && committedVote !== undefined ? (
@@ -1060,13 +1055,6 @@ const StyledRadioGroup = styled(Radio.Group)`
 
 const SecondaryActionText = styled.div`
   margin-top: 30px;
-`;
-
-const StyledJustificationNote = styled.div`
-  font-size: 12px;
-  margin: -12px auto 12px;
-  opacity: 0.8;
-  width: 70%;
 `;
 
 const StyledInputTextArea = styled(Input.TextArea)`


### PR DESCRIPTION
Resolves #617.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the rendering logic in the `src/components/case-details-card.jsx` file by removing unnecessary fragments and a styled component related to justification notes.

### Detailed summary
- Removed a fragment that wrapped the `JustificationBox` and `StyledJustificationNote`.
- Deleted the `StyledJustificationNote` styled component entirely.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the hidden-vote justification interface by removing an unnecessary saved-draft note.
  * Improved consistency by displaying only the justification box in this workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->