### PR TITLE
chore: whitelist PoH Governor address

### DIFF
--- a/src/temp/arbitrable-whitelist.js
+++ b/src/temp/arbitrable-whitelist.js
@@ -37,6 +37,7 @@ const arbitrableWhitelist = {
     "0xf339047c85d0dd2645f2bd802a1e8a5e7af61053",
     "0xf65c7560d6ce320cc3a16a07f1f65aab66396b9e",
     "0xbE9834097A4E97689d9B667441acafb456D0480A", // PoH V2
+    "0x327a29fcE0a6490E4236240Be176dAA282EcCfdF", // PoH Governor
     ...MAINNET_REALITY_ADDRESSES,
   ].map((address) => address.toLowerCase()),
   100: [


### PR DESCRIPTION
Resolves #619.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new address for the "PoH Governor" to the `src/temp/arbitrable-whitelist.js` file, while ensuring all addresses are converted to lowercase.

### Detailed summary
- Added the address `0x327a29fcE0a6490E4236240Be176dAA282EcCfdF` for "PoH Governor".
- The comments indicate the purpose of the new address addition.
- Maintained the structure of existing address mapping.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the PoH Governor to the Ethereum mainnet arbitrable whitelist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->