### PR TITLE
fix: update docs link in smart contract wallet warning

### DIFF
--- a/src/components/smart-contract-wallet-warning.js
+++ b/src/components/smart-contract-wallet-warning.js
@@ -83,7 +83,7 @@ function WalletWarningPerAccount({ account }) {
         <StyledP>
           You are using a smart contract wallet. This is not recommended.{" "}
           <a
-            href="https://docs.kleros.io/kleros-faq#can-i-use-a-smart-contract-account-to-stake-in-the-court"
+            href="https://docs.kleros.io/welcome/faq#can-i-use-a-smart-contract-account-to-stake-in-the-court"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Resolves #621.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the URL in the warning message about using a smart contract wallet. 

### Detailed summary
- Changed the `href` attribute of the `<a>` tag from `https://docs.kleros.io/kleros-faq#can-i-use-a-smart-contract-account-to-stake-in-the-court` to `https://docs.kleros.io/welcome/faq#can-i-use-a-smart-contract-account-to-stake-in-the-court`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the smart-contract wallet warning’s “Learn more” link to point to the latest Kleros documentation FAQ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->